### PR TITLE
Add PHPCS and standard ruleset

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 /vendor/
 composer.lock
 composer.phar
+.idea
+.project

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ before_script:
     - travis_retry composer install --no-interaction
 
 script:
+    - vendor/bin/phpcs -n .
     - vendor/bin/phpunit --coverage-clover=coverage.xml
 
 after_success:

--- a/composer.json
+++ b/composer.json
@@ -13,8 +13,9 @@
 		"php": "^7.2"
 	},
 	"require-dev": {
+		"mikey179/vfsstream": "^1.6",
 		"phpunit/phpunit": "^6",
-		"mikey179/vfsstream": "^1.6"
+		"slevomat/coding-standard": "^4.5.2"
 	},
 	"autoload": {
 		"psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
 	"require-dev": {
 		"mikey179/vfsstream": "^1.6",
 		"phpunit/phpunit": "^6",
-		"slevomat/coding-standard": "^4.5.2"
+		"slevomat/coding-standard": "^4"
 	},
 	"autoload": {
 		"psr-4": {

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0"?>
+
+<ruleset name="Custom Standard">
+ <!--Exclude Paths-->
+ <exclude-pattern type="relative">vendor/*</exclude-pattern>
+ <exclude-pattern type="relative">docs/*</exclude-pattern>
+
+ <!--Generic Rules-->
+ <rule ref="PSR1"/>
+ <rule ref="PSR2"/>
+ <rule ref="Generic.Arrays.DisallowLongArraySyntax"/>
+ <rule ref="Generic.CodeAnalysis.EmptyStatement"/>
+ <rule ref="Generic.CodeAnalysis.UnconditionalIfStatement"/>
+ <rule ref="Generic.CodeAnalysis.UnusedFunctionParameter"/>
+ <rule ref="Generic.CodeAnalysis.UselessOverridingMethod"/>
+ <rule ref="Generic.ControlStructures.InlineControlStructure"/>
+ <rule ref="Generic.Commenting.Fixme"/>
+ <rule ref="Generic.Commenting.Todo"/>
+ <rule ref="Generic.Files.LineLength">
+  <properties>
+   <property name="lineLimit" value="120"/>
+   <property name="absoluteLineLimit" value="120"/>
+  </properties>
+ </rule>
+ <rule ref="Generic.Formatting.DisallowMultipleStatements"/>
+ <rule ref="Generic.Formatting.NoSpaceAfterCast"/>
+ <rule ref="Generic.Functions.FunctionCallArgumentSpacing"/>
+ <rule ref="Generic.Metrics.CyclomaticComplexity"/>
+ <rule ref="Generic.Metrics.NestingLevel"/>
+ <rule ref="Generic.NamingConventions.UpperCaseConstantName"/>
+ <rule ref="Generic.PHP.LowerCaseConstant"/>
+ <rule ref="Generic.PHP.CharacterBeforePHPOpeningTag"/>
+ <rule ref="Generic.PHP.NoSilencedErrors">
+  <properties>
+   <property name="error" value="true"/>
+  </properties>
+ </rule>
+ <rule ref="Generic.WhiteSpace.DisallowTabIndent"/>
+
+ <!--Slevomat Rules-->
+ <rule ref="vendor/slevomat/coding-standard/SlevomatCodingStandard/Sniffs/Namespaces/UnusedUsesSniff.php">
+  <properties>
+   <property name="searchAnnotations" value="true"/>
+  </properties>
+ </rule>
+ <rule ref="SlevomatCodingStandard.Classes.ClassConstantVisibility"/>
+ <rule ref="SlevomatCodingStandard.Commenting.EmptyComment"/>
+ <rule ref="SlevomatCodingStandard.ControlStructures.RequireShortTernaryOperator"/>
+ <rule ref="SlevomatCodingStandard.Namespaces.FullyQualifiedGlobalFunctions"/>
+ <rule ref="SlevomatCodingStandard.Namespaces.NamespaceDeclaration"/>
+ <rule ref="SlevomatCodingStandard.Namespaces.RequireOneNamespaceInFile"/>
+ <rule ref="SlevomatCodingStandard.TypeHints.ParameterTypeHintSpacing"/>
+ <rule ref="SlevomatCodingStandard.TypeHints.ReturnTypeHintSpacing"/>
+
+ <!--Arguments-->
+ <arg name="colors"/>
+ <arg value="sp"/>
+</ruleset>

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -46,7 +46,6 @@
  <rule ref="SlevomatCodingStandard.Classes.ClassConstantVisibility"/>
  <rule ref="SlevomatCodingStandard.Commenting.EmptyComment"/>
  <rule ref="SlevomatCodingStandard.ControlStructures.RequireShortTernaryOperator"/>
- <rule ref="SlevomatCodingStandard.Namespaces.FullyQualifiedGlobalFunctions"/>
  <rule ref="SlevomatCodingStandard.Namespaces.NamespaceDeclaration"/>
  <rule ref="SlevomatCodingStandard.Namespaces.RequireOneNamespaceInFile"/>
  <rule ref="SlevomatCodingStandard.TypeHints.ParameterTypeHintSpacing"/>

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0"?>
 
 <ruleset name="Custom Standard">
+ <config name="installed_paths" value="../../slevomat/coding-standard"/>
+
  <!--Exclude Paths-->
  <exclude-pattern type="relative">vendor/*</exclude-pattern>
  <exclude-pattern type="relative">docs/*</exclude-pattern>
@@ -38,7 +40,7 @@
  <rule ref="Generic.WhiteSpace.DisallowTabIndent"/>
 
  <!--Slevomat Rules-->
- <rule ref="vendor/slevomat/coding-standard/SlevomatCodingStandard/Sniffs/Namespaces/UnusedUsesSniff.php">
+ <rule ref="SlevomatCodingStandard.Namespaces.UnusedUses">
   <properties>
    <property name="searchAnnotations" value="true"/>
   </properties>

--- a/src/Alias/Data/Alias.php
+++ b/src/Alias/Data/Alias.php
@@ -21,58 +21,57 @@ use Jstewmc\Gravity\Id\Data\Id;
  */
 abstract class Alias
 {
-	/* !Private properties */
+    /* !Private properties */
 
-	/**
-	 * @var    Id  the destination id
-	 * @since  0.1.0
-	 */
-	private $destination;
+    /**
+     * @var    Id  the destination id
+     * @since  0.1.0
+     */
+    private $destination;
 
-	/**
-	 * @var    Id  the source id
-	 * @since  0.1.0
-	 */
-	private $source;
+    /**
+     * @var    Id  the source id
+     * @since  0.1.0
+     */
+    private $source;
+
+    /* !Magic methods */
+
+    /**
+     * Called when the alias is constructed
+     *
+     * @param   Id $source      the source id
+     * @param   Id $destination the destination id
+     * @since   0.1.0
+     */
+    public function __construct(Id $source, Id $destination)
+    {
+        $this->source      = $source;
+        $this->destination = $destination;
+    }
 
 
-	/* !Magic methods */
+    /* !Get methods */
 
-	/**
-	 * Called when the alias is constructed
-	 *
-	 * @param   Id  $source       the source id
-	 * @param   Id  $destination  the destination id
-	 * @since   0.1.0
-	 */
-	public function __construct(Id $source, Id $destination)
-	{
-		$this->source      = $source;
-		$this->destination = $destination;
-	}
+    /**
+     * Returns the alias' destination identifier
+     *
+     * @return  Id
+     * @since   0.1.0
+     */
+    public function getDestination(): Id
+    {
+        return $this->destination;
+    }
 
-
-	/* !Get methods */
-
-	/**
-	 * Returns the alias' destination identifier
-	 *
-	 * @return  Id
-	 * @since   0.1.0
-	 */
-	public function getDestination(): Id
-	{
-		return $this->destination;
-	}
-
-	/**
-	 * Returns the alias' source identifier
-	 *
-	 * @return  Id
-	 * @since   0.1.0
-	 */
-	public function getSource(): Id
-	{
-		return $this->source;
-	}
+    /**
+     * Returns the alias' source identifier
+     *
+     * @return  Id
+     * @since   0.1.0
+     */
+    public function getSource(): Id
+    {
+        return $this->source;
+    }
 }

--- a/src/Alias/Exception/Circular.php
+++ b/src/Alias/Exception/Circular.php
@@ -18,18 +18,18 @@ use Jstewmc\Gravity\Id\Data\Id;
  */
 class Circular extends Exception
 {
-	/* !Magic methods */
+    /* !Magic methods */
 
-	/**
-	 * Called when the exception is constructed
-	 *
-	 * @param  Id  $id  the circular identifier
-	 * @since  0.1.
-	 */
-	public function __construct(Id $id)
-	{
-		parent::__construct($id);
-		
-		$this->message = "Circular alias for '$id'";
-	}
+    /**
+     * Called when the exception is constructed
+     *
+     * @param  Id $id the circular identifier
+     * @since  0.1.
+     */
+    public function __construct(Id $id)
+    {
+        parent::__construct($id);
+
+        $this->message = "Circular alias for '$id'";
+    }
 }

--- a/src/Alias/Exception/NotFound.php
+++ b/src/Alias/Exception/NotFound.php
@@ -18,18 +18,18 @@ use Jstewmc\Gravity\Id\Data\Id;
  */
 class NotFound extends Exception
 {
-	/* !Magic methods */
+    /* !Magic methods */
 
-	/**
-	 * Called when the exception is constructed
-	 *
-	 * @param  Id  $id  the identifier not found
-	 * @since  0.1.
-	 */
-	public function __construct(Id $id)
-	{
-		parent::__construct($id);
+    /**
+     * Called when the exception is constructed
+     *
+     * @param  Id $id the identifier not found
+     * @since  0.1.
+     */
+    public function __construct(Id $id)
+    {
+        parent::__construct($id);
 
-		$this->message = "Alias '$id' not found";
-	}
+        $this->message = "Alias '$id' not found";
+    }
 }

--- a/src/Alias/Service/Parse.php
+++ b/src/Alias/Service/Parse.php
@@ -9,19 +9,13 @@
 
 namespace Jstewmc\Gravity\Alias\Service;
 
-use Jstewmc\Gravity\Alias\Data\{
-    Alias,
-    Service as ServiceAlias,
-    Setting as SettingAlias
-};
+use Jstewmc\Gravity\Alias\Data\Alias;
+use Jstewmc\Gravity\Alias\Data\Service as ServiceAlias;
+use Jstewmc\Gravity\Alias\Data\Setting as SettingAlias;
 use Jstewmc\Gravity\Alias\Exception\Circular;
-use Jstewmc\Gravity\Id\Data\{
-    Id,
-    Service as ServiceId,
-    Setting as SettingId
-};
+use Jstewmc\Gravity\Id\Data\Id;
+use Jstewmc\Gravity\Id\Data\Service as ServiceId;
 use Jstewmc\Gravity\Id\Service\Parse as ParseId;
-
 
 /**
  * Parses a setting or service alias
@@ -37,7 +31,6 @@ class Parse
      * @since  0.1.0
      */
     private $parseId;
-
 
     /* !Magic methods */
 
@@ -55,8 +48,8 @@ class Parse
     /**
      * Called when the service is treated like a function
      *
-     * @param   string  $source       the source identifier
-     * @param   string  $destination  the destination identifier
+     * @param   string $source      the source identifier
+     * @param   string $destination the destination identifier
      * @return  Alias
      * @throws  Circular  if $source equals $destination
      * @since   0.1.0
@@ -67,14 +60,14 @@ class Parse
         $destination = $this->parseId($destination);
 
         if ($source == $destination) {
-			throw new Circular($source, $destination);
-		}
+            throw new Circular($source, $destination);
+        }
 
-		if ($source instanceof ServiceId) {
-			$alias = new ServiceAlias($source, $destination);
-		} else {
-			$alias = new SettingAlias($source, $destination);
-		}
+        if ($source instanceof ServiceId) {
+            $alias = new ServiceAlias($source, $destination);
+        } else {
+            $alias = new SettingAlias($source, $destination);
+        }
 
         return $alias;
     }
@@ -85,7 +78,7 @@ class Parse
     /**
      * Parses a string identifier
      *
-     * @param   string  $id  the identifier to parse
+     * @param   string $id the identifier to parse
      * @return  Id
      * @since   0.1.0
      */

--- a/src/Cache/Data/Hash.php
+++ b/src/Cache/Data/Hash.php
@@ -9,9 +9,8 @@
 
 namespace Jstewmc\Gravity\Cache\Data;
 
-use Jstewmc\Gravity\Id\Data\Id;
 use Jstewmc\Gravity\Cache\Exception\NotFound;
-
+use Jstewmc\Gravity\Id\Data\Id;
 
 /**
  * A simple hash-based cache
@@ -41,11 +40,11 @@ class Hash implements Cache
      */
     public function get(Id $id)
     {
-        if ( ! $this->has($id)) {
+        if (!$this->has($id)) {
             throw new NotFound($id);
         }
 
-        return $this->values[(string) $id];
+        return $this->values[(string)$id];
     }
 
     /**
@@ -57,7 +56,7 @@ class Hash implements Cache
      */
     public function has(Id $id): bool
     {
-        return array_key_exists((string) $id, $this->values);
+        return array_key_exists((string)$id, $this->values);
     }
 
     /**
@@ -70,7 +69,7 @@ class Hash implements Cache
     public function remove(Id $id): void
     {
         if ($this->has($id)) {
-            unset($this->values[(string) $id]);
+            unset($this->values[(string)$id]);
         }
 
         return;
@@ -99,7 +98,7 @@ class Hash implements Cache
      */
     public function set(Id $id, $value): Cache
     {
-        $this->values[(string) $id] = $value;
+        $this->values[(string)$id] = $value;
 
         return $this;
     }

--- a/src/Definition/Data/Definition.php
+++ b/src/Definition/Data/Definition.php
@@ -11,7 +11,6 @@ namespace Jstewmc\Gravity\Definition\Data;
 
 use Jstewmc\Gravity\Id\Data\Id;
 
-
 /**
  * A setting or service definition
  *

--- a/src/Definition/Service/Get.php
+++ b/src/Definition/Service/Get.php
@@ -10,16 +10,13 @@
 namespace Jstewmc\Gravity\Definition\Service;
 
 use Jstewmc\Gravity\Cache\Data\Cache;
-use Jstewmc\Gravity\Id\Data\{
-    Id,
-    Service as ServiceId,
-    Setting as SettingId
-};
+use Jstewmc\Gravity\Id\Data\Id;
+use Jstewmc\Gravity\Id\Data\Service as ServiceId;
+use Jstewmc\Gravity\Id\Data\Setting as SettingId;
 use Jstewmc\Gravity\Id\Service\Find as FindId;
 use Jstewmc\Gravity\Project\Data\Project;
 use Jstewmc\Gravity\Service\Service\Get as GetService;
 use Jstewmc\Gravity\Setting\Service\Get as GetSetting;
-
 
 /**
  * The get-definition service
@@ -66,15 +63,15 @@ class Get
      * @param   Cache       $cache       the cache to use
      */
     public function __construct(
-        FindId      $findId,
-        GetService  $getService,
-        GetSetting  $getSetting,
-        Cache       $cache
-    ){
-        $this->findId      = $findId;
-        $this->getService  = $getService;
-        $this->getSetting  = $getSetting;
-        $this->cache       = $cache;
+        FindId $findId,
+        GetService $getService,
+        GetSetting $getSetting,
+        Cache $cache
+    ) {
+        $this->findId     = $findId;
+        $this->getService = $getService;
+        $this->getSetting = $getSetting;
+        $this->cache      = $cache;
     }
 
     /**

--- a/src/Definition/Service/Parse.php
+++ b/src/Definition/Service/Parse.php
@@ -10,11 +10,9 @@
 namespace Jstewmc\Gravity\Definition\Service;
 
 use Jstewmc\Gravity\Definition\Data\Definition;
-use Jstewmc\Gravity\Id\Data\{
-    Id,
-    Service as ServiceId,
-    Setting as SettingId
-};
+use Jstewmc\Gravity\Id\Data\Id;
+use Jstewmc\Gravity\Id\Data\Service as ServiceId;
+use Jstewmc\Gravity\Id\Data\Setting as SettingId;
 use Jstewmc\Gravity\Id\Service\Parse as ParseId;
 use Jstewmc\Gravity\Service\Data\Service as ServiceDefinition;
 use Jstewmc\Gravity\Service\Service\Parse as ParseService;
@@ -60,13 +58,13 @@ class Parse
      * @since  0.1.0
      */
     public function __construct(
-        ParseId  $parseId,
-        ParseService     $parseService,
-        ParseSetting     $parseSetting
+        ParseId $parseId,
+        ParseService $parseService,
+        ParseSetting $parseSetting
     ) {
-        $this->parseId = $parseId;
-        $this->parseService    = $parseService;
-        $this->parseSetting    = $parseSetting;
+        $this->parseId      = $parseId;
+        $this->parseService = $parseService;
+        $this->parseSetting = $parseSetting;
     }
 
     /**

--- a/src/Deprecation/Data/Deprecation.php
+++ b/src/Deprecation/Data/Deprecation.php
@@ -9,9 +9,7 @@
 
 namespace Jstewmc\Gravity\Deprecation\Data;
 
-use Jstewmc\Gravity\Deprecation\Exception\Circular;
 use Jstewmc\Gravity\Id\Data\Id;
-
 
 /**
  * A setting or service deprecation
@@ -24,89 +22,88 @@ use Jstewmc\Gravity\Id\Data\Id;
  */
 abstract class Deprecation
 {
-	/* !Private properties */
+    /* !Private properties */
 
-	/**
-	 * @var    Id  the deprecated identifier
-	 * @since  0.1.0
-	 */
-	private $id;
+    /**
+     * @var    Id  the deprecated identifier
+     * @since  0.1.0
+     */
+    private $id;
 
-	/**
-	 * @var    Id|null  the replacement identifier (optional)
-	 * @since  0.1.0
-	 */
-	private $replacement;
+    /**
+     * @var    Id|null  the replacement identifier (optional)
+     * @since  0.1.0
+     */
+    private $replacement;
 
+    /* !Magic methods */
 
-	/* !Magic methods */
-
-	/**
-	 * Called when the deprecation is constructed
-	 *
-	 * @param   Id       $id   the deprecated identifier
-	 * @param   Id|null  $replacement  the replacement identifier (optional)
-	 * @since   0.1.0
-	 */
-	public function __construct(Id $id, ?Id $replacement)
-	{
-		$this->identifier  = $id;
-		$this->replacement = $replacement;
-	}
-
-
-	/* !Get methods */
-
-	/**
-	 * Returns the deprecated identifier
-	 *
-	 * @return  Id
-	 * @since   0.1.0
-	 */
-	public function getId(): Id
-	{
-		return $this->identifier;
-	}
-
-	/**
-	 * Returns the deprecation's replacement
-	 *
-	 * @return  Id|null
-	 * @since   0.1.0
-	 */
-	public function getReplacement(): ?Id
-	{
-		return $this->replacement;
-	}
+    /**
+     * Called when the deprecation is constructed
+     *
+     * @param   Id      $id          the deprecated identifier
+     * @param   Id|null $replacement the replacement identifier (optional)
+     * @since   0.1.0
+     */
+    public function __construct(Id $id, ?Id $replacement)
+    {
+        $this->id          = $id;
+        $this->replacement = $replacement;
+    }
 
 
-	/* !Set methods */
+    /* !Get methods */
 
-	/**
-	 * Sets the deprecation's replacement
-	 *
-	 * @param   Id  $replacement
-	 * @return  self
-	 * @since   0.1.0
-	 */
-	public function setReplacement(Id $replacement): self
-	{
-		$this->replacement = $replacement;
+    /**
+     * Returns the deprecated identifier
+     *
+     * @return  Id
+     * @since   0.1.0
+     */
+    public function getId(): Id
+    {
+        return $this->id;
+    }
 
-		return $this;
-	}
+    /**
+     * Returns the deprecation's replacement
+     *
+     * @return  Id|null
+     * @since   0.1.0
+     */
+    public function getReplacement(): ?Id
+    {
+        return $this->replacement;
+    }
 
 
-	/* !Public methods */
+    /* !Set methods */
 
-	/**
-	 * Returns true if a replacement exists
-	 *
-	 * @return  bool
-	 * @since   0.1.0
-	 */
-	public function hasReplacement(): bool
-	{
-		return $this->replacement !== null;
-	}
+    /**
+     * Sets the deprecation's replacement
+     *
+     * @param   Id $replacement
+     * @return  self
+     * @since   0.1.0
+     */
+    public function setReplacement(Id $replacement): self
+    {
+        $this->replacement = $replacement;
+
+        return $this;
+    }
+
+
+    /* !Public methods */
+
+    /**
+     * Returns true if a replacement exists
+     *
+     * @return  bool
+     * @since   0.1.0
+     */
+    public function hasReplacement(): bool
+    {
+        return $this->replacement !== null;
+    }
 }

--- a/src/Deprecation/Exception/Circular.php
+++ b/src/Deprecation/Exception/Circular.php
@@ -18,18 +18,18 @@ use Jstewmc\Gravity\Id\Data\Id;
  */
 class Circular extends Exception
 {
-	/* !Magic methods */
+    /* !Magic methods */
 
-	/**
-	 * Called when the exception is constructed
-	 *
-	 * @param  Id  $id   the deprecated identifier
-	 * @since  0.1.
-	 */
-	public function __construct(Id $id)
-	{
-		parent::__construct($id);
+    /**
+     * Called when the exception is constructed
+     *
+     * @param  Id $id the deprecated identifier
+     * @since  0.1.
+     */
+    public function __construct(Id $id)
+    {
+        parent::__construct($id);
 
-		$this->message = "Cicular deprecation for '$id'";
-	}
+        $this->message = "Cicular deprecation for '$id'";
+    }
 }

--- a/src/Deprecation/Service/Parse.php
+++ b/src/Deprecation/Service/Parse.php
@@ -9,17 +9,12 @@
 
 namespace Jstewmc\Gravity\Deprecation\Service;
 
-use Jstewmc\Gravity\Deprecation\Data\{
-    Deprecation,
-    Service as ServiceDeprecation,
-    Setting as SettingDeprecation
-};
+use Jstewmc\Gravity\Deprecation\Data\Deprecation;
+use Jstewmc\Gravity\Deprecation\Data\Service as ServiceDeprecation;
+use Jstewmc\Gravity\Deprecation\Data\Setting as SettingDeprecation;
 use Jstewmc\Gravity\Deprecation\Exception\Circular;
-use Jstewmc\Gravity\Id\Data\{
-    Id,
-    Service as ServiceId,
-    Setting as SettingId
-};
+use Jstewmc\Gravity\Id\Data\Id;
+use Jstewmc\Gravity\Id\Data\Service as ServiceId;
 use Jstewmc\Gravity\Id\Service\Parse as ParseId;
 
 /**
@@ -64,8 +59,8 @@ class Parse
         if ($replacement) {
             $replacement = $this->parseId($replacement);
             if ($id == $replacement) {
-    			throw new Circular($id, $replacement);
-    		}
+                throw new Circular($id, $replacement);
+            }
         }
 
         if ($id instanceof ServiceId) {

--- a/src/Deprecation/Service/Warn.php
+++ b/src/Deprecation/Service/Warn.php
@@ -18,46 +18,46 @@ use Jstewmc\Gravity\Deprecation\Data\Deprecation;
  */
 class Warn
 {
-	/* !Magic methods */
+    /* !Magic methods */
 
-	/**
-	 * Called when the service is treated like a function
-	 *
-	 * @param   Deprecation  $deprecation  the deprecation used
-	 * @return  void
-	 * @since   0.1.0
-	 */
-	public function __invoke(Deprecation $deprecation): void
-	{
-		$message = $this->getMessage($deprecation);
+    /**
+     * Called when the service is treated like a function
+     *
+     * @param   Deprecation $deprecation the deprecation used
+     * @return  void
+     * @since   0.1.0
+     */
+    public function __invoke(Deprecation $deprecation): void
+    {
+        $message = $this->getMessage($deprecation);
 
-		trigger_error($message, E_USER_DEPRECATED);
+        trigger_error($message, E_USER_DEPRECATED);
 
-		return;
-	}
+        return;
+    }
 
 
-	/* !Private methods */
+    /* !Private methods */
 
-	/**
-	 * Creates the error message
-	 *
-	 * @param   Deprecation  $deprecation
-	 * @return  string
-	 * @since   0.1.0
-	 */
-	private function getMessage(Deprecation $deprecation): string
-	{
-		$message = "The service, setting, or alias "
-			. "'{$deprecation->getId()}' has been deprecated and "
-			. "should be";
+    /**
+     * Creates the error message
+     *
+     * @param   Deprecation $deprecation
+     * @return  string
+     * @since   0.1.0
+     */
+    private function getMessage(Deprecation $deprecation): string
+    {
+        $message = "The service, setting, or alias "
+            . "'{$deprecation->getId()}' has been deprecated and "
+            . "should be";
 
-		if ($deprecation->hasReplacement()) {
-			$message .= "replaced with '{$deprecation->getReplacement()}'";
-		} else {
-			$message .= "removed";
-		}
+        if ($deprecation->hasReplacement()) {
+            $message .= "replaced with '{$deprecation->getReplacement()}'";
+        } else {
+            $message .= "removed";
+        }
 
-		return $message;
-	}
+        return $message;
+    }
 }

--- a/src/Filesystem/Exception/Filesystem.php
+++ b/src/Filesystem/Exception/Filesystem.php
@@ -11,7 +11,6 @@ namespace Jstewmc\Gravity\Filesystem\Exception;
 
 use Jstewmc\Gravity\Exception;
 
-
 /**
  * Thrown when a filesystem exception occurs
  *

--- a/src/Filesystem/Service/Find.php
+++ b/src/Filesystem/Service/Find.php
@@ -10,7 +10,9 @@
 namespace Jstewmc\Gravity\Filesystem\Service;
 
 use Jstewmc\Gravity\Filesystem\Data\Filesystem;
-use Jstewmc\Gravity\Filesystem\Exception\{NotFound, NotReadable, NotDirectory};
+use Jstewmc\Gravity\Filesystem\Exception\NotDirectory;
+use Jstewmc\Gravity\Filesystem\Exception\NotFound;
+use Jstewmc\Gravity\Filesystem\Exception\NotReadable;
 use SplFileInfo;
 
 /**
@@ -33,31 +35,30 @@ use SplFileInfo;
  */
 class Find
 {
-	/* !Private constants */
+    /* !Private constants */
 
-	/**
-	 * @var    int  the number of levels down from the root directory
-	 * @since  0.1.0
-	 */
-	private const LEVELS = 6;
+    /**
+     * @var    int  the number of levels down from the root directory
+     * @since  0.1.0
+     */
+    private const LEVELS = 6;
 
-
-	/* !Magic methods */
+    /* !Magic methods */
 
     /**
      * Called when the service is treated like a function
      *
      * @return  string|null
-	 * @throws  NotFound      if project's root directory does not exist
-	 * @throws  NotReadable   if project's root directory is not readable
-	 * @throws  NotDirectory  if project's root directory is not a directory
+     * @throws  NotFound      if project's root directory does not exist
+     * @throws  NotReadable   if project's root directory is not readable
+     * @throws  NotDirectory  if project's root directory is not a directory
      * @since   0.1.0
      */
     public function __invoke(): ?string
     {
-		if ( ! $this->isComposer()) {
-			return null;
-		}
+        if (!$this->isComposer()) {
+            return null;
+        }
 
         $pathname = realpath(dirname(__FILE__, self::LEVELS));
 
@@ -65,11 +66,11 @@ class Find
             throw new NotFound($pathname);
         }
 
-        if ( ! is_readable($pathname)) {
+        if (!is_readable($pathname)) {
             throw new NotReadable($pathname);
         }
 
-        if ( ! is_dir($pathname)) {
+        if (!is_dir($pathname)) {
             throw new NotDirectory($pathname);
         }
 
@@ -77,37 +78,35 @@ class Find
     }
 
 
-	/* !Private methods */
+    /* !Private methods */
 
-	/**
-	 * Returns true if the package was installed using Composer
-	 *
-	 * I assume the package is installed by Composer if the directory
-	 * immediately below the expected root directory is the Composer directory.
-	 *
-	 * This may be false in some situations, but it seems like a sensible
-	 * assumption.
-	 *
-	 * @return  bool
-	 * @since   0.1.0
-	 */
-	private function isComposer(): bool
-	{
-		$pathname = realpath(dirname(__FILE__, self::LEVELS - 1));
+    /**
+     * Returns true if the package was installed using Composer
+     * I assume the package is installed by Composer if the directory
+     * immediately below the expected root directory is the Composer directory.
+     * This may be false in some situations, but it seems like a sensible
+     * assumption.
+     *
+     * @return  bool
+     * @since   0.1.0
+     */
+    private function isComposer(): bool
+    {
+        $pathname = realpath(dirname(__FILE__, self::LEVELS - 1));
 
-		if ( ! $pathname) {
-			return false;
-		}
+        if (!$pathname) {
+            return false;
+        }
 
-		$directory = new SplFileInfo($pathname);
+        $directory = new SplFileInfo($pathname);
 
-		if ( ! $directory->isReadable() || ! $directory->isDir()) {
-			return false;
-		}
+        if (!$directory->isReadable() || !$directory->isDir()) {
+            return false;
+        }
 
-		$expected = Filesystem::DIRECTORY_NAME_VENDORS;
-		$actual   = $directory->getFilename();
+        $expected = Filesystem::DIRECTORY_NAME_VENDORS;
+        $actual   = $directory->getFilename();
 
-		return $expected === $actual;
-	}
+        return $expected === $actual;
+    }
 }

--- a/src/Filesystem/Service/Load.php
+++ b/src/Filesystem/Service/Load.php
@@ -24,14 +24,14 @@ class Load
     /**
      * Called when the service is treated like a function
      *
-     * @param   Filesystem  $filesystem  the filesystem to read
-	 * @param   Manager     $g           the Gravity manager
-	 * @return  Manager
+     * @param   Filesystem $filesystem the filesystem to read
+     * @param   Manager    $g          the Gravity manager
+     * @return  Manager
      * @since   0.1.0
      */
     public function __invoke(Filesystem $filesystem, Manager $g): Manager
     {
-		foreach ($filesystem->getFiles() as $file) {
+        foreach ($filesystem->getFiles() as $file) {
             include $file->getPathname();
         }
 

--- a/src/Filesystem/Service/Read.php
+++ b/src/Filesystem/Service/Read.php
@@ -106,7 +106,7 @@ class Read
         $vendors = $this->implode($root, Filesystem::DIRECTORY_NAME_VENDORS);
 
         // if a vendors directory doesn't exist, short-circuit
-        if ( ! $this->isDirectory($vendors)) {
+        if (!$this->isDirectory($vendors)) {
             return [];
         }
 

--- a/src/Id/Data/Id.php
+++ b/src/Id/Data/Id.php
@@ -11,7 +11,6 @@ namespace Jstewmc\Gravity\Id\Data;
 
 /**
  * Uniquely identifies a service or setting across the project
- *
  * An identifier is composed of three or more case-insensitive segments (i.e., a
  * vendor name, a package name, and a path) separated by a separator character
  * (i.e., a backslash ("\") for services and period (".") for settings).
@@ -20,60 +19,58 @@ namespace Jstewmc\Gravity\Id\Data;
  */
 abstract class Id
 {
-	/* !Public constants */
+    /* !Public constants */
 
-	/**
-	 * @var    string  the identifier's separator character (MUST be defined
-	 *     in each child class)
-	 * @since  0.1.0
-	 */
-	public const SEPARATOR = '';
+    /**
+     * @var    string  the identifier's separator character (MUST be defined
+     *     in each child class)
+     * @since  0.1.0
+     */
+    public const SEPARATOR = '';
 
+    /* !Private properties */
 
-	/* !Private properties */
+    /**
+     * @var    string[]  the identifier's segments
+     * @since  0.1.0
+     */
+    private $segments;
 
-	/**
-	 * @var    string[]  the identifier's segments
-	 * @since  0.1.0
-	 */
-	private $segments;
+    /* !Magic methods */
 
+    /**
+     * Called when the identifier is constructed
+     *
+     * @param   string[] $segments the identifier's segments
+     * @since   0.1.0
+     */
+    public function __construct(array $segments)
+    {
+        $this->segments = $segments;
+    }
 
-	/* !Magic methods */
-
-	/**
-	 * Called when the identifier is constructed
-	 *
-	 * @param   string[]  $segments  the identifier's segments
-	 * @since   0.1.0
-	 */
-	public function __construct(array $segments)
-	{
-		$this->segments = $segments;
-	}
-
-	/**
-	 * Called when the identifier is treated like a string
-	 *
-	 * @return  string
-	 * @since   0.1.0
-	 */
-	public function __toString(): string
-	{
-		return implode(static::SEPARATOR, $this->segments);
-	}
+    /**
+     * Called when the identifier is treated like a string
+     *
+     * @return  string
+     * @since   0.1.0
+     */
+    public function __toString(): string
+    {
+        return implode(static::SEPARATOR, $this->segments);
+    }
 
 
-	/* !Get methods */
+    /* !Get methods */
 
-	/**
-	 * Returns the identifier's segments
-	 *
-	 * @return  string[]
-	 * @since   0.1.0
-	 */
-	public function getSegments(): array
-	{
-		return $this->segments;
-	}
+    /**
+     * Returns the identifier's segments
+     *
+     * @return  string[]
+     * @since   0.1.0
+     */
+    public function getSegments(): array
+    {
+        return $this->segments;
+    }
 }

--- a/src/Id/Exception/BadSeparator.php
+++ b/src/Id/Exception/BadSeparator.php
@@ -9,7 +9,8 @@
 
 namespace Jstewmc\Gravity\Id\Exception;
 
-use Jstewmc\Gravity\Id\Data\{Service, Setting};
+use Jstewmc\Gravity\Id\Data\Service;
+use Jstewmc\Gravity\Id\Data\Setting;
 
 /**
  * Thrown when an identifier doesn't contain a valid separator

--- a/src/Id/Service/Parse.php
+++ b/src/Id/Service/Parse.php
@@ -9,9 +9,11 @@
 
 namespace Jstewmc\Gravity\Id\Service;
 
-use Jstewmc\Gravity\Id\Data\{Id, Service, Setting};
-use Jstewmc\Gravity\Id\Exception\{BadLength, BadSeparator};
-
+use Jstewmc\Gravity\Id\Data\Id;
+use Jstewmc\Gravity\Id\Data\Service;
+use Jstewmc\Gravity\Id\Data\Setting;
+use Jstewmc\Gravity\Id\Exception\BadLength;
+use Jstewmc\Gravity\Id\Exception\BadSeparator;
 
 /**
  * Parses an identifier
@@ -20,149 +22,149 @@ use Jstewmc\Gravity\Id\Exception\{BadLength, BadSeparator};
  */
 class Parse
 {
-	/* !Magic methods */
+    /* !Magic methods */
 
-	/**
-	 * Called when the service is treated like a function
-	 *
-	 * @param   string  $id  the identifier to parse
-	 * @return  Id
-	 * @since   0.1.0
-	 */
-	public function __invoke(string $id): Id
-	{
-		$separator = $this->getSeparator($id);
+    /**
+     * Called when the service is treated like a function
+     *
+     * @param   string $id the identifier to parse
+     * @return  Id
+     * @since   0.1.0
+     */
+    public function __invoke(string $id): Id
+    {
+        $separator = $this->getSeparator($id);
 
-		$segments = $this->getSegments($id, $separator);
+        $segments = $this->getSegments($id, $separator);
 
-		if ($separator === Service::SEPARATOR) {
-			$id = new Service($segments);
-		} else {
-			$id = new Setting($segments);
-		}
+        if ($separator === Service::SEPARATOR) {
+            $id = new Service($segments);
+        } else {
+            $id = new Setting($segments);
+        }
 
-		return $id;
-	}
+        return $id;
+    }
 
 
-	/* !Private methods */
+    /* !Private methods */
 
-	/**
-	 * Downcases an identifier
-	 *
-	 * @param   string  $id  the identifier to downcase
-	 * @return  string
-	 * @since   0.1.0
-	 */
-	private function downcase(string $id): string
-	{
-		return strtolower($id);
-	}
+    /**
+     * Downcases an identifier
+     *
+     * @param   string $id the identifier to downcase
+     * @return  string
+     * @since   0.1.0
+     */
+    private function downcase(string $id): string
+    {
+        return strtolower($id);
+    }
 
-	/**
-	 * Explodes the identifier into segments, removing empties
-	 *
-	 * @param   string  $id  the identifier to explode
-	 * @param   string  $separator   the identifier's separator
-	 * @return  string[]
-	 * @since   0.1.0
-	 */
-	private function explode(string $id, string $separator): array
-	{
-		return array_values(array_filter(explode($separator, $id)));
-	}
+    /**
+     * Explodes the identifier into segments, removing empties
+     *
+     * @param   string $id        the identifier to explode
+     * @param   string $separator the identifier's separator
+     * @return  string[]
+     * @since   0.1.0
+     */
+    private function explode(string $id, string $separator): array
+    {
+        return array_values(array_filter(explode($separator, $id)));
+    }
 
-	/**
-	 * Returns the identifier's segments
-	 *
-	 * @param   string  $id  the identifier
-	 * @param   string  $separator   the identifier's separator
-	 * @return  string[]
-	 * @throws  BadLength  if $id has too few segments
-	 * @since   0.1.0
-	 */
-	private function getSegments(string $id, string $separator): array
-	{
-		$id = $this->trim($id);
-		$id = $this->downcase($id);
-		$id = $this->popSeparator($id, $separator);
-		$id = $this->shiftSeparator($id, $separator);
+    /**
+     * Returns the identifier's segments
+     *
+     * @param   string $id        the identifier
+     * @param   string $separator the identifier's separator
+     * @return  string[]
+     * @throws  BadLength  if $id has too few segments
+     * @since   0.1.0
+     */
+    private function getSegments(string $id, string $separator): array
+    {
+        $id = $this->trim($id);
+        $id = $this->downcase($id);
+        $id = $this->popSeparator($id, $separator);
+        $id = $this->shiftSeparator($id, $separator);
 
-		$segments = $this->explode($id, $separator);
+        $segments = $this->explode($id, $separator);
 
-		if (count($segments) < 3) {
-			throw new BadLength($id);
-		}
+        if (count($segments) < 3) {
+            throw new BadLength($id);
+        }
 
-		return $segments;
-	}
+        return $segments;
+    }
 
-	/**
-	 * Returns the identifier's separator
-	 *
-	 * @param   string  $id  the identifier to test
-	 * @return  string
-	 * @throws  BadSeparator  if $id doesn't contain valid separator
-	 * @since   0.1.0
-	 */
-	private function getSeparator(string $id): string
-	{
-		$separator = null;
+    /**
+     * Returns the identifier's separator
+     *
+     * @param   string $id the identifier to test
+     * @return  string
+     * @throws  BadSeparator  if $id doesn't contain valid separator
+     * @since   0.1.0
+     */
+    private function getSeparator(string $id): string
+    {
+        $separator = null;
 
-		if (strpos($id, Service::SEPARATOR) !== false) {
-			$separator = Service::SEPARATOR;
-		} elseif (strpos($id, Setting::SEPARATOR) !== false) {
-			$separator = Setting::SEPARATOR;
-		} else {
-			throw new BadSeparator($id);
-		}
+        if (strpos($id, Service::SEPARATOR) !== false) {
+            $separator = Service::SEPARATOR;
+        } elseif (strpos($id, Setting::SEPARATOR) !== false) {
+            $separator = Setting::SEPARATOR;
+        } else {
+            throw new BadSeparator($id);
+        }
 
-		return $separator;
-	}
+        return $separator;
+    }
 
-	/**
-	 * Pops a trailing separator off the end of the separator, if it exists
-	 *
-	 * @param   string  $id  the identifier
-	 * @param   string  $separator   the identifier's separator
-	 * @return  string
-	 * @since   0.1.0
-	 */
-	private function popSeparator(string $id, string $separator): string
-	{
-		if (substr($id, -1) === $separator) {
-			$id = substr($id, 0, -1);
-		}
+    /**
+     * Pops a trailing separator off the end of the separator, if it exists
+     *
+     * @param   string $id        the identifier
+     * @param   string $separator the identifier's separator
+     * @return  string
+     * @since   0.1.0
+     */
+    private function popSeparator(string $id, string $separator): string
+    {
+        if (substr($id, -1) === $separator) {
+            $id = substr($id, 0, -1);
+        }
 
-		return $id;
-	}
+        return $id;
+    }
 
-	/**
-	 * Shifts a leading separator off the front of the identifier, if it exists
-	 *
-	 * @param   string  $id  the identifier
-	 * @param   string  $separator   the identifier's separator
-	 * @return  string
-	 * @since   0.1.0
-	 */
-	private function shiftSeparator(string $id, string $separator): string
-	{
-		if (substr($id, 0, 1) === $separator) {
-			$id = substr($id, 1);
-		}
+    /**
+     * Shifts a leading separator off the front of the identifier, if it exists
+     *
+     * @param   string $id        the identifier
+     * @param   string $separator the identifier's separator
+     * @return  string
+     * @since   0.1.0
+     */
+    private function shiftSeparator(string $id, string $separator): string
+    {
+        if (substr($id, 0, 1) === $separator) {
+            $id = substr($id, 1);
+        }
 
-		return $id;
-	}
+        return $id;
+    }
 
-	/**
-	 * Trims leading- and trailing-spaces
-	 *
-	 * @param   string  $id  the identifier to trim
-	 * @return  string
-	 * @since   0.1.0
-	 */
-	private function trim(string $id): string
-	{
-		return trim($id);
-	}
+    /**
+     * Trims leading- and trailing-spaces
+     *
+     * @param   string $id the identifier to trim
+     * @return  string
+     * @since   0.1.0
+     */
+    private function trim(string $id): string
+    {
+        return trim($id);
+    }
 }

--- a/src/Manager.php
+++ b/src/Manager.php
@@ -11,24 +11,17 @@ namespace Jstewmc\Gravity;
 
 use Jstewmc\Gravity\Alias\Data\Alias;
 use Jstewmc\Gravity\Alias\Service\Parse as ParseAlias;
-use Jstewmc\Gravity\Definition\Data\{
-    Definition,
-    Service as ServiceDefinition,
-    Setting as SettingDefinition
-};
-use Jstewmc\Gravity\Definition\Service\{
-    Parse as ParseDefinition,
-    Get as GetDefinition
-};
+use Jstewmc\Gravity\Definition\Data\Definition;
+use Jstewmc\Gravity\Definition\Data\Service as ServiceDefinition;
+use Jstewmc\Gravity\Definition\Service\Get as GetDefinition;
+use Jstewmc\Gravity\Definition\Service\Parse as ParseDefinition;
 use Jstewmc\Gravity\Deprecation\Data\Deprecation;
 use Jstewmc\Gravity\Deprecation\Service\Parse as ParseDeprecation;
-use Jstewmc\Gravity\Filesystem\Service\{
-    Find as FindFilesystem,
-    Read as ReadFilesystem,
-    Load as LoadFilesystem
-};
+use Jstewmc\Gravity\Deprecation\Service\Warn;
+use Jstewmc\Gravity\Filesystem\Service\Find as FindFilesystem;
+use Jstewmc\Gravity\Filesystem\Service\Load as LoadFilesystem;
+use Jstewmc\Gravity\Filesystem\Service\Read as ReadFilesystem;
 use Jstewmc\Gravity\Project\Data\Project;
-
 
 /**
  * The Gravity manager
@@ -272,7 +265,7 @@ class Manager
         $cache = new Cache\Data\Hash();
 
         // instantiate the "get-side" services
-        $warnDeprecation = new \Jstewmc\Gravity\Deprecation\Service\Warn();
+        $warnDeprecation = new Warn();
 
         $resolveId = new Id\Service\Resolve($warnDeprecation);
         $findId    = new Id\Service\Find($parseId, $resolveId);
@@ -320,7 +313,7 @@ class Manager
     {
         $root = (new FindFilesystem())();
 
-        if ( ! $root) {
+        if (!$root) {
             return;
         }
 

--- a/src/Manager.php
+++ b/src/Manager.php
@@ -122,10 +122,10 @@ class Manager
      * Aliases help move things around, but in general, should be used lightly.
      * It's a better world if a service or setting has a single identifier.
      *
-     * @example  alias a service
+     * @example  Alias a service
      *    $g->alias('Foo\Bar\Baz');
      *
-     * @example  alias a setting
+     * @example  Alias a setting
      *    $g->alias('foo.bar.baz');
      *
      * @param   string  $source       the alias' source identifier

--- a/src/Project/Data/Project.php
+++ b/src/Project/Data/Project.php
@@ -13,11 +13,9 @@ use Jstewmc\Gravity\Alias\Data\Alias;
 use Jstewmc\Gravity\Alias\Exception\NotFound as AliasNotFound;
 use Jstewmc\Gravity\Deprecation\Data\Deprecation;
 use Jstewmc\Gravity\Deprecation\Exception\NotFound as DeprecationNotFound;
-use Jstewmc\Gravity\Id\Data\{
-    Id,
-    Service as ServiceId,
-    Setting as SettingId
-};
+use Jstewmc\Gravity\Id\Data\Id;
+use Jstewmc\Gravity\Id\Data\Service as ServiceId;
+use Jstewmc\Gravity\Id\Data\Setting as SettingId;
 use Jstewmc\Gravity\Service\Data\Service;
 use Jstewmc\Gravity\Service\Exception\NotFound as ServiceNotFound;
 use Jstewmc\Gravity\Setting\Data\Setting;
@@ -68,7 +66,7 @@ class Project
      */
     public function addAlias(Alias $alias): self
     {
-        $this->aliases[(string) $alias->getSource()] = $alias;
+        $this->aliases[(string)$alias->getSource()] = $alias;
 
         return $this;
     }
@@ -82,7 +80,7 @@ class Project
      */
     public function addDeprecation(Deprecation $deprecation): self
     {
-        $this->deprecations[(string) $deprecation->getId()] = $deprecation;
+        $this->deprecations[(string)$deprecation->getId()] = $deprecation;
 
         return $this;
     }
@@ -96,7 +94,7 @@ class Project
      */
     public function addService(Service $service): self
     {
-        $this->services[(string) $service->getId()] = $service;
+        $this->services[(string)$service->getId()] = $service;
 
         return $this;
     }
@@ -124,7 +122,7 @@ class Project
      */
     public function hasAlias(Id $id): bool
     {
-        return array_key_exists((string) $id, $this->aliases);
+        return array_key_exists((string)$id, $this->aliases);
     }
 
     /**
@@ -136,7 +134,7 @@ class Project
      */
     public function hasDeprecation(Id $id): bool
     {
-        return array_key_exists((string) $id, $this->deprecations);
+        return array_key_exists((string)$id, $this->deprecations);
     }
 
     /**
@@ -148,7 +146,7 @@ class Project
      */
     public function hasService(Id $id): bool
     {
-        return array_key_exists((string) $id, $this->services);
+        return array_key_exists((string)$id, $this->services);
     }
 
     /**
@@ -163,7 +161,7 @@ class Project
         $settings = $this->settings;
 
         foreach ($id->getSegments() as $segment) {
-            if ( ! array_key_exists($segment, $settings)) {
+            if (!array_key_exists($segment, $settings)) {
                 return false;
             }
             $settings = $settings[$segment];
@@ -182,11 +180,11 @@ class Project
      */
     public function getAlias(Id $id): Alias
     {
-        if ( ! $this->hasAlias($id)) {
+        if (!$this->hasAlias($id)) {
             throw new AliasNotFound($id);
         }
 
-        return $this->aliases[(string) $id];
+        return $this->aliases[(string)$id];
     }
 
     /**
@@ -199,11 +197,11 @@ class Project
      */
     public function getDeprecation(Id $id): Deprecation
     {
-        if ( ! $this->hasDeprecation($id)) {
+        if (!$this->hasDeprecation($id)) {
             throw new DeprecationNotFound($id);
         }
 
-        return $this->deprecations[(string) $id];
+        return $this->deprecations[(string)$id];
     }
 
     /**
@@ -216,11 +214,11 @@ class Project
      */
     public function getService(ServiceId $id): Service
     {
-        if ( ! $this->hasService($id)) {
+        if (!$this->hasService($id)) {
             throw new ServiceNotFound($id);
         }
 
-        return $this->services[(string) $id];
+        return $this->services[(string)$id];
     }
 
     /**
@@ -233,7 +231,7 @@ class Project
      */
     public function getSetting(SettingId $id)
     {
-        if ( ! $this->hasSetting($id)) {
+        if (!$this->hasSetting($id)) {
             throw new SettingNotFound($id);
         }
 
@@ -250,8 +248,7 @@ class Project
     /* !Private methods */
 
     /**
-	 * Merges two arrays recursively
-     *
+     * Merges two arrays recursively
      * PHP's native array_merge_recursive() function combines the scalar values
      * of duplicate string keys into an array instead of overwriting the first
      * value with the second value.
@@ -259,42 +256,36 @@ class Project
      * @example  PHP's native function
      *     $a = ["foo" => "bar"];
      *     $b = ["foo" => "baz"];
-     *
      *     array_merge_recursive($a, $b);  // returns ["foo" => ["bar","baz"]]
-     *
      * I, on the other hand, will merge arrays so that scalar values in the
      * second array overwrite the values in the first.
-     *
      * @example  merge two arrays recursively
      *     $a = ["foo" => "bar"];
      *     $b = ["foo" => "baz"];
-     *
      *     $this->merge($a, $b);  // returns ["foo" => "baz"]
-     *
-	 * @param   mixed[]  $a  the first array
-	 * @param   mixed[]  $b  the second array (takes precedence)
-	 * @return  mixed[]
-	 * @since   0.1.0
-	 * @see     http://php.net/manual/en/function.array-merge-recursive.php#92195
-	 *     gabriel dot sobrinho at gmail dot com's commnent on the
-	 *     array_merge_recursive() man page (accessed 11/26/17)
-	 * @todo    hmm, what do we do with zero-indexed arrays (see failing test)
-	 */
-	private function merge(array $a, array $b): array
-	{
-		// loop through the second array
-		foreach ($b as $k => $v) {
-			// if the value is an array, the key exists in $a, and the value in
+     * @param   mixed[] $a the first array
+     * @param   mixed[] $b the second array (takes precedence)
+     * @return  mixed[]
+     * @since    0.1.0
+     * @see      http://php.net/manual/en/function.array-merge-recursive.php#92195
+     *                     gabriel dot sobrinho at gmail dot com's commnent on the
+     *                     array_merge_recursive() man page (accessed 11/26/17)
+     * @todo     hmm, what do we do with zero-indexed arrays (see failing test)
+     */
+    private function merge(array $a, array $b): array
+    {
+        // loop through the second array
+        foreach ($b as $k => $v) {
+            // if the value is an array, the key exists in $a, and the value in
             // $a sn an array, merge it recursively; otherwise, just set it in
             // $a
-			//
-			if (is_array($v) && isset($a[$k]) && is_array($a[$k])) {
-				$a[$k] = ($this)($a[$k], $v);
-			} else {
-				$a[$k] = $v;
-			}
-		}
+            if (is_array($v) && isset($a[$k]) && is_array($a[$k])) {
+                $a[$k] = ($this)($a[$k], $v);
+            } else {
+                $a[$k] = $v;
+            }
+        }
 
-		return $a;
-	}
+        return $a;
+    }
 }

--- a/src/Service/Data/Factory.php
+++ b/src/Service/Data/Factory.php
@@ -9,9 +9,7 @@
 
 namespace Jstewmc\Gravity\Service\Data;
 
-use Jstewmc\Gravity\Factory as FactoryInterface;
 use Jstewmc\Gravity\Id\Data\Service as Id;
-
 
 /**
  * A factory-defined service

--- a/src/Service/Data/Fx.php
+++ b/src/Service/Data/Fx.php
@@ -11,7 +11,6 @@ namespace Jstewmc\Gravity\Service\Data;
 
 use Jstewmc\Gravity\Id\Data\Service as Id;
 
-
 /**
  * An anonymous-function-defined service
  *
@@ -28,7 +27,7 @@ class Fx extends Service
      * @param  Callable    $definition  the service's definition
      * @since  0.1.0
      */
-    public function __construct(Id $id, Callable $definition)
+    public function __construct(Id $id, callable $definition)
     {
         parent::__construct($id, $definition);
     }
@@ -39,10 +38,10 @@ class Fx extends Service
     /**
      * Returns the service's definition
      *
-     * @return  Callable
+     * @return  callable
      * @since   0.1.0
      */
-    public function getDefinition(): Callable
+    public function getDefinition(): callable
     {
         return parent::getDefinition();
     }

--- a/src/Service/Data/Instance.php
+++ b/src/Service/Data/Instance.php
@@ -11,7 +11,6 @@ namespace Jstewmc\Gravity\Service\Data;
 
 use Jstewmc\Gravity\Id\Data\Service as Id;
 
-
 /**
  * An instance-defined service
  *

--- a/src/Service/Data/Newable.php
+++ b/src/Service/Data/Newable.php
@@ -11,7 +11,6 @@ namespace Jstewmc\Gravity\Service\Data;
 
 use Jstewmc\Gravity\Id\Data\Service as Id;
 
-
 /**
  * A newable-defined service
  *

--- a/src/Service/Service/Instantiate.php
+++ b/src/Service/Service/Instantiate.php
@@ -10,7 +10,11 @@
 namespace Jstewmc\Gravity\Service\Service;
 
 use Jstewmc\Gravity\Manager;
-use Jstewmc\Gravity\Service\Data\{Factory, Fx, Instance, Newable, Service};
+use Jstewmc\Gravity\Service\Data\Factory;
+use Jstewmc\Gravity\Service\Data\Fx;
+use Jstewmc\Gravity\Service\Data\Instance;
+use Jstewmc\Gravity\Service\Data\Newable;
+use Jstewmc\Gravity\Service\Data\Service;
 
 /**
  * Instantiates a service
@@ -117,7 +121,7 @@ class Instantiate
      */
     public function instantiateNewable(Newable $service): object
     {
-        $classname = (string) $service->getId();
+        $classname = (string)$service->getId();
 
         return new $classname;
     }

--- a/src/Service/Service/Parse.php
+++ b/src/Service/Service/Parse.php
@@ -11,8 +11,11 @@ namespace Jstewmc\Gravity\Service\Service;
 
 use Jstewmc\Gravity\Factory as FactoryInterface;
 use Jstewmc\Gravity\Id\Data\Service as Id;
-use Jstewmc\Gravity\Id\Service\Parse as ParseId;
-use Jstewmc\Gravity\Service\Data\{Factory, Fx, Instance, Newable, Service};
+use Jstewmc\Gravity\Service\Data\Factory;
+use Jstewmc\Gravity\Service\Data\Fx;
+use Jstewmc\Gravity\Service\Data\Instance;
+use Jstewmc\Gravity\Service\Data\Newable;
+use Jstewmc\Gravity\Service\Data\Service;
 use Jstewmc\Gravity\Service\Exception\BadDefinition;
 
 /**
@@ -54,36 +57,36 @@ class Parse
     /* !Private methods */
 
     /**
-	 * Returns true if the service is an anonymous function
-	 *
-	 * @param   mixed  $value  the value to test
-	 * @return  bool
-	 * @since   0.1.0
-	 */
-	private function isFunction($value): bool
-	{
-		return is_callable($value);
-	}
+     * Returns true if the service is an anonymous function
+     *
+     * @param   mixed $value the value to test
+     * @return  bool
+     * @since   0.1.0
+     */
+    private function isFunction($value): bool
+    {
+        return is_callable($value);
+    }
 
-	/**
-	 * Returns true if the service is a factory
-	 *
-	 * @param   mixed  $value  the value to test
-	 * @return  bool
-	 * @since   0.1.0
-	 */
-	private function isFactory($value): bool
-	{
+    /**
+     * Returns true if the service is a factory
+     *
+     * @param   mixed $value the value to test
+     * @return  bool
+     * @since   0.1.0
+     */
+    private function isFactory($value): bool
+    {
         // apparently, instanceof does not accept strings
-		return is_string($value)
+        return is_string($value)
             && class_exists($value)
             && is_subclass_of($value, FactoryInterface::class);
-	}
+    }
 
     /**
      * Returns true if the service is a service instance
      *
-     * @param   mixed  $value  the value to test
+     * @param   mixed $value the value to test
      * @return  bool
      * @since   0.1.0
      */
@@ -95,7 +98,7 @@ class Parse
     /**
      * Returns true if the service is a newable service
      *
-     * @param   mixed  $value  the value to test
+     * @param   mixed $value the value to test
      * @return  bool
      * @since   0.1.0
      */

--- a/src/Setting/Service/Parse.php
+++ b/src/Setting/Service/Parse.php
@@ -48,71 +48,65 @@ class Parse
     /* !Private methods */
 
     /**
-	 * Downcase an array's keys
+     * Downcase an array's keys
      *
      * @example  lower-case the array keys
      *     $this->downcase(['FOO' => 'bar']);  // returns ['foo' => 'bar']
-	 *
-	 * @param   array  $array   the array to downcase
-	 * @return  array
-	 * @since   0.1.0
-	 * @see     https://stackoverflow.com/a/23299766  Mike Starov's answer to
-     *     "How to convert all keys in a multi-dimensional array to snake_case?"
-     *     on Stack Overflow (accessed 2017-12-29)
-	 */
-	private function downcase(array $array): array
-	{
-		return array_map(function ($item) {
-			if (is_array($item)) {
-				$item = $this->downcase($item);
-			}
+     * @param   array $array the array to downcase
+     * @return  array
+     * @since    0.1.0
+     * @see      https://stackoverflow.com/a/23299766  Mike Starov's answer to
+     *  "How to convert all keys in a multi-dimensional array to snake_case?"
+     *  on Stack Overflow (accessed 2017-12-29)
+     */
+    private function downcase(array $array): array
+    {
+        return array_map(
+            function ($item) {
+                if (is_array($item)) {
+                    $item = $this->downcase($item);
+                }
 
-			return $item;
-		}, array_change_key_case($array));
-	}
+                return $item;
+            },
+            array_change_key_case($array)
+        );
+    }
 
     /**
-	 * Converts a path and value into a single array
-	 *
-	 * Settings are defined as key-value pairs, but they're stored in a single
+     * Converts a path and value into a single array
+     * Settings are defined as key-value pairs, but they're stored in a single
      * consolidated array.
-     *
      * Ids can be of any length (e.g., "foo.bar" or "foo.bar.baz.quz"),
      * and values may be scalar or arrays of arbitrary depth (e.g., 1, "foo",
      * or ["foo" => "bar"]).
-	 *
      * Before we can add a setting to a package's existing settings array, we
      * must normalize it to a standard array.
-     *
-	 * I'll normalize any identifier-value pair into an associative array so
+     * I'll normalize any identifier-value pair into an associative array so
      * they can be merged into the existing configuration set.
-	 *
-	 * @example  converting arbitrary identifier-value pairs (in pseudo-code)
-	 *     $a = $this->toArray("foo.bar.baz", "qux");
-	 *     $b = $this->toArray("foo.bar", ["baz" => "qux"]);
-	 *     $c = $this->toArray("foo", ["bar" => ["baz" => "qux"]]);
-	 *
-	 *     $a === $b;  // returns true
-	 *     $b === $c;  // returns true
-	 *
-	 * In the example above, $a, $b, and $c are equivalent to the following:
-	 *
-	 *     [
-	 *         "foo" => [
-	 *             "bar" => [
-	 *                 "baz" => "qux"
-	 *             ]
-	 *         ]
-	 *     ]
-	 *
-     * @param   Id  $id  the setting's identifier
-	 * @param   mixed       $value       the setting's value
-	 * @return  array
-	 * @since   0.1.0
-	 */
-	public function toArray(Id $id, $value): array
-	{
-		$array = [];
+     *
+     * @example  converting arbitrary identifier-value pairs (in pseudo-code)
+     *     $a = $this->toArray("foo.bar.baz", "qux");
+     *     $b = $this->toArray("foo.bar", ["baz" => "qux"]);
+     *     $c = $this->toArray("foo", ["bar" => ["baz" => "qux"]]);
+     *     $a === $b;  // returns true
+     *     $b === $c;  // returns true
+     * In the example above, $a, $b, and $c are equivalent to the following:
+     *     [
+     *         "foo" => [
+     *             "bar" => [
+     *                 "baz" => "qux"
+     *             ]
+     *         ]
+     *     ]
+     * @param   Id    $id    the setting's identifier
+     * @param   mixed $value the setting's value
+     * @return  array
+     * @since    0.1.0
+     */
+    public function toArray(Id $id, $value): array
+    {
+        $array = [];
 
         // at this point, the identifier's segments are ordered from first-to-
         // last, left-to-right
@@ -120,20 +114,18 @@ class Parse
         //
         // reverse them from innermost to outermost
         // e.g., ["foo", "bar", "baz"] -> ["baz", "bar", "foo"]
-        //
-		$segments = array_reverse($id->getSegments());
+        $segments = array_reverse($id->getSegments());
 
-		// now, nest the values from the inside out
+        // now, nest the values from the inside out
         // e.g., (i=0) ["baz" => $value]
         // e.g., (i=1) ["bar" => ["baz" => $value]]
         // e.g., (i=2) ["foo" => ["bar" => ["baz" => $value]]]
-        //
-		foreach ($segments as $k => $segment) {
-			$array[$segment] = $value;
-			$value = $array;
-            $array = [];
-		}
+        foreach ($segments as $k => $segment) {
+            $array[$segment] = $value;
+            $value           = $array;
+            $array           = [];
+        }
 
-		return $value;
-	}
+        return $value;
+    }
 }

--- a/tests/Alias/Service/ParseTest.php
+++ b/tests/Alias/Service/ParseTest.php
@@ -9,16 +9,12 @@
 
 namespace Jstewmc\Gravity\Alias\Service;
 
-use Jstewmc\Gravity\Alias\Data\{
-    Service as ServiceAlias,
-    Setting as SettingAlias
-};
+use Jstewmc\Gravity\Alias\Data\Service as ServiceAlias;
+use Jstewmc\Gravity\Alias\Data\Setting as SettingAlias;
 use Jstewmc\Gravity\Alias\Exception\Circular;
-use Jstewmc\Gravity\Id\Data\{
-    Id,
-    Service as ServiceId,
-    Setting as SettingId
-};
+use Jstewmc\Gravity\Id\Data\Id;
+use Jstewmc\Gravity\Id\Data\Service as ServiceId;
+use Jstewmc\Gravity\Id\Data\Setting as SettingId;
 use Jstewmc\Gravity\Id\Service\Parse as ParseId;
 use PHPUnit\Framework\TestCase;
 

--- a/tests/Cache/Data/HashTest.php
+++ b/tests/Cache/Data/HashTest.php
@@ -23,7 +23,7 @@ class HashTest extends TestCase
 {
     /* get, has, remove, reset, and set */
 
-    public function testGet_throwsException_ifValueDoesNotExist(): void
+    public function testGetThrowsExceptionIfValueDoesNotExist(): void
     {
         $this->expectException(NotFound::class);
 

--- a/tests/Definition/Service/GetTest.php
+++ b/tests/Definition/Service/GetTest.php
@@ -10,11 +10,9 @@
 namespace Jstewmc\Gravity\Definition\Service;
 
 use Jstewmc\Gravity\Cache\Data\Cache;
-use Jstewmc\Gravity\Id\Data\{
-    Id,
-    Service as ServiceId,
-    Setting as SettingId
-};
+use Jstewmc\Gravity\Id\Data\Id;
+use Jstewmc\Gravity\Id\Data\Service as ServiceId;
+use Jstewmc\Gravity\Id\Data\Setting as SettingId;
 use Jstewmc\Gravity\Id\Service\Find as FindId;
 use Jstewmc\Gravity\Project\Data\Project;
 use Jstewmc\Gravity\Service\Service\Get as GetService;

--- a/tests/Definition/Service/ParseTest.php
+++ b/tests/Definition/Service/ParseTest.php
@@ -9,10 +9,8 @@
 
 namespace Jstewmc\Gravity\Definition\Service;
 
-use Jstewmc\Gravity\Id\Data\{
-    Service as ServiceId,
-    Setting as SettingId
-};
+use Jstewmc\Gravity\Id\Data\Service as ServiceId;
+use Jstewmc\Gravity\Id\Data\Setting as SettingId;
 use Jstewmc\Gravity\Id\Service\Parse as ParseId;
 use Jstewmc\Gravity\Service\Service\Parse as ParseService;
 use Jstewmc\Gravity\Setting\Service\Parse as ParseSetting;
@@ -28,7 +26,9 @@ class ParseTest extends TestCase
     public function testInvokeReturnsServiceIfService(): void
     {
         $id = $this->createMock(ServiceId::class);
-        $value      = function () { return; };
+        $value      = function () {
+            return;
+        };
 
         // stub the parse-identifier service to return the identifier
         $parseId = $this->createMock(ParseId::class);

--- a/tests/Deprecation/Data/ServiceTest.php
+++ b/tests/Deprecation/Data/ServiceTest.php
@@ -12,7 +12,6 @@ namespace Jstewmc\Gravity\Deprecation\Data;
 use Jstewmc\Gravity\Id\Data\Service as Id;
 use PHPUnit\Framework\TestCase;
 
-
 /**
  * Tests for a service deprecation
  *

--- a/tests/Deprecation/Data/SettingTest.php
+++ b/tests/Deprecation/Data/SettingTest.php
@@ -12,7 +12,6 @@ namespace Jstewmc\Gravity\Deprecation\Data;
 use Jstewmc\Gravity\Id\Data\Setting as Id;
 use PHPUnit\Framework\TestCase;
 
-
 /**
  * Tests for a setting deprecation
  *

--- a/tests/Deprecation/Service/ParseTest.php
+++ b/tests/Deprecation/Service/ParseTest.php
@@ -9,17 +9,12 @@
 
 namespace Jstewmc\Gravity\Deprecation\Service;
 
-use Jstewmc\Gravity\Deprecation\Data\{
-    Deprecation,
-    Service as ServiceDeprecation,
-    Setting as SettingDeprecation
-};
+use Jstewmc\Gravity\Deprecation\Data\Service as ServiceDeprecation;
+use Jstewmc\Gravity\Deprecation\Data\Setting as SettingDeprecation;
 use Jstewmc\Gravity\Deprecation\Exception\Circular;
-use Jstewmc\Gravity\Id\Data\{
-    Id,
-    Service as ServiceId,
-    Setting as SettingId
-};
+use Jstewmc\Gravity\Id\Data\Id;
+use Jstewmc\Gravity\Id\Data\Service as ServiceId;
+use Jstewmc\Gravity\Id\Data\Setting as SettingId;
 use Jstewmc\Gravity\Id\Service\Parse as ParseId;
 use PHPUnit\Framework\TestCase;
 

--- a/tests/Deprecation/Service/WarnTest.php
+++ b/tests/Deprecation/Service/WarnTest.php
@@ -9,10 +9,12 @@
 
 namespace Jstewmc\Gravity\Deprecation\Service;
 
-use Jstewmc\Gravity\Deprecation\Data\Service as Deprecation;  // either one
+use Jstewmc\Gravity\Deprecation\Data\Service as Deprecation;
 use Jstewmc\Gravity\Id\Data\Service as Id;
 use PHPUnit\Framework\Error\Deprecated;
 use PHPUnit\Framework\TestCase;
+
+// either one
 
 /**
  * Tests for the warn-deprecation service
@@ -26,32 +28,32 @@ use PHPUnit\Framework\TestCase;
  *
  * @since  0.1.0
  */
-class WarnDeprecationTest extends TestCase
+class WarnTest extends TestCase
 {
     public function testInvokeTriggersErrorIfReplacementDoesNotExist(): void
-	{
-		$this->expectException(Deprecated::class);
+    {
+        $this->expectException(Deprecated::class);
 
-		$id = $this->createMock(Id::class);
+        $id = $this->createMock(Id::class);
 
-		$deprecation = new Deprecation($id);
+        $deprecation = new Deprecation($id);
 
-		(new Warn())($deprecation);
+        (new Warn())($deprecation);
 
-		return;
-	}
+        return;
+    }
 
-	public function testInvokeTriggersErrorIfReplacementDoesExist(): void
-	{
-		$this->expectException(Deprecated::class);
+    public function testInvokeTriggersErrorIfReplacementDoesExist(): void
+    {
+        $this->expectException(Deprecated::class);
 
-		$id  = $this->createMock(Id::class);
-		$replacement = $this->createMock(Id::class);
+        $id          = $this->createMock(Id::class);
+        $replacement = $this->createMock(Id::class);
 
-		$deprecation = new Deprecation($id, $replacement);
+        $deprecation = new Deprecation($id, $replacement);
 
-		(new Warn())($deprecation);
+        (new Warn())($deprecation);
 
-		return;
-	}
+        return;
+    }
 }

--- a/tests/Filesystem/Service/LoadTest.php
+++ b/tests/Filesystem/Service/LoadTest.php
@@ -11,7 +11,8 @@ namespace Jstewmc\Gravity\Filesystem\Service;
 
 use Jstewmc\Gravity\Filesystem\Data\Filesystem;
 use Jstewmc\Gravity\Manager;
-use org\bovigo\vfs\{vfsStream, vfsStreamDirectory, vfsStreamFile};
+use org\bovigo\vfs\vfsStream;
+use org\bovigo\vfs\vfsStreamDirectory;
 use PHPUnit\Framework\TestCase;
 use SplFileInfo;
 
@@ -45,12 +46,14 @@ class LoadTest extends TestCase
     {
         // create a valid gravity file (location doesn't matter)
         $file = vfsStream::newFile('foo.php')
-			->withContent('<?php
+            ->withContent(
+                '<?php
                 $g->alias("foo\bar\baz", "foo\bar\qux");
                 $g->set("foo\bar\qux");
                 $g->deprecate("foo\bar\baz");
-            ')
-			->at($this->root);
+            '
+            )
+            ->at($this->root);
 
         // set up a filesystem to return the file
         $file = new SplFileInfo($file->url());

--- a/tests/Filesystem/Service/ReadTest.php
+++ b/tests/Filesystem/Service/ReadTest.php
@@ -10,7 +10,8 @@
 namespace Jstewmc\Gravity\Filesystem\Service;
 
 use Jstewmc\Gravity\Filesystem\Data\Filesystem;
-use org\bovigo\vfs\{vfsStream, vfsStreamDirectory, vfsStreamFile};
+use org\bovigo\vfs\vfsStream;
+use org\bovigo\vfs\vfsStreamDirectory;
 use PHPUnit\Framework\TestCase;
 use SplFileInfo;
 

--- a/tests/Id/Data/ServiceTest.php
+++ b/tests/Id/Data/ServiceTest.php
@@ -23,7 +23,7 @@ class ServiceTest extends TestCase
     {
         $this->assertEquals(
             'foo\bar\baz',
-            (string) new Service(['foo', 'bar', 'baz'])
+            (string)new Service(['foo', 'bar', 'baz'])
         );
 
         return;
@@ -33,7 +33,7 @@ class ServiceTest extends TestCase
     {
         $segments = ['foo', 'bar', 'baz'];
 
-        $this->assertEquals($segments,(new Service($segments))->getSegments());
+        $this->assertEquals($segments, (new Service($segments))->getSegments());
 
         return;
     }

--- a/tests/Id/Data/SettingTest.php
+++ b/tests/Id/Data/SettingTest.php
@@ -23,7 +23,7 @@ class SettingTest extends TestCase
     {
         $this->assertEquals(
             'foo.bar.baz',
-            (string) new Setting(['foo', 'bar', 'baz'])
+            (string)new Setting(['foo', 'bar', 'baz'])
         );
 
         return;

--- a/tests/Id/Service/ParseTest.php
+++ b/tests/Id/Service/ParseTest.php
@@ -9,9 +9,10 @@
 
 namespace Jstewmc\Gravity\Id\Service;
 
-use Jstewmc\Gravity\Id\Data\Service as Id;  // either one works
-use Jstewmc\Gravity\Id\Exception\{BadLength, BadSeparator};
-use PHPUnit\Framework\TestCase;
+use Jstewmc\Gravity\Id\Data\Service as Id;
+use Jstewmc\Gravity\Id\Exception\BadLength;
+use Jstewmc\Gravity\Id\Exception\BadSeparator;
+use PHPUnit\Framework\TestCase;  // either one works
 
 /**
  * Tests for the parse-identifier service

--- a/tests/ManagerTest.php
+++ b/tests/ManagerTest.php
@@ -9,7 +9,6 @@
 
 namespace Jstewmc\Gravity;
 
-use Jstewmc\Gravity\Setting\Exception\NotFound;
 use PHPUnit\Framework\TestCase;
 
 /**

--- a/tests/Project/Data/ProjectTest.php
+++ b/tests/Project/Data/ProjectTest.php
@@ -13,11 +13,9 @@ use Jstewmc\Gravity\Alias\Data\Alias;
 use Jstewmc\Gravity\Alias\Exception\NotFound as AliasNotFound;
 use Jstewmc\Gravity\Deprecation\Data\Deprecation;
 use Jstewmc\Gravity\Deprecation\Exception\NotFound as DeprecationNotFound;
-use Jstewmc\Gravity\Id\Data\{
-    Id,
-    Service as ServiceId,
-    Setting as SettingId
-};
+use Jstewmc\Gravity\Id\Data\Id;
+use Jstewmc\Gravity\Id\Data\Service as ServiceId;
+use Jstewmc\Gravity\Id\Data\Setting as SettingId;
 use Jstewmc\Gravity\Service\Data\Service;
 use Jstewmc\Gravity\Service\Exception\NotFound as ServiceNotFound;
 use Jstewmc\Gravity\Setting\Data\Setting;

--- a/tests/Service/Data/FactoryTest.php
+++ b/tests/Service/Data/FactoryTest.php
@@ -10,7 +10,6 @@
 namespace Jstewmc\Gravity\Service\Data;
 
 use Jstewmc\Gravity\Id\Data\Service as Id;
-use Jstewmc\Gravity\Factory as FactoryInterface;
 use PHPUnit\Framework\TestCase;
 
 /**

--- a/tests/Service/Data/FxTest.php
+++ b/tests/Service/Data/FxTest.php
@@ -23,7 +23,9 @@ class FxTest extends TestCase
     {
         $id = $this->createMock(Id::class);
 
-        $service = new Fx($id, function () { return; });
+        $service = new Fx($id, function () {
+            return;
+        });
 
         $this->assertSame($id, $service->getId());
 
@@ -33,7 +35,9 @@ class FxTest extends TestCase
     public function testGetDefinition(): void
     {
         $id = $this->createMock(Id::class);
-        $definition = function () { return; };
+        $definition = function () {
+            return;
+        };
 
         $service = new Fx($id, $definition);
 

--- a/tests/Service/Data/NewableTest.php
+++ b/tests/Service/Data/NewableTest.php
@@ -11,7 +11,6 @@ namespace Jstewmc\Gravity\Service\Data;
 
 use Jstewmc\Gravity\Id\Data\Service as Id;
 use PHPUnit\Framework\TestCase;
-use StdClass;
 
 /**
  * Tests for a newable service

--- a/tests/Service/Service/InstantiateTest.php
+++ b/tests/Service/Service/InstantiateTest.php
@@ -9,10 +9,13 @@
 
 namespace Jstewmc\Gravity\Service\Service;
 
-use Jstewmc\Gravity\Id\Data\Service as Id;
 use Jstewmc\Gravity\FactoryTest;
+use Jstewmc\Gravity\Id\Data\Service as Id;
 use Jstewmc\Gravity\Manager;
-use Jstewmc\Gravity\Service\Data\{Factory, Fx, Instance, Newable};
+use Jstewmc\Gravity\Service\Data\Factory;
+use Jstewmc\Gravity\Service\Data\Fx;
+use Jstewmc\Gravity\Service\Data\Instance;
+use Jstewmc\Gravity\Service\Data\Newable;
 use PHPUnit\Framework\TestCase;
 use StdClass;
 
@@ -45,7 +48,9 @@ class InstantiateTest extends TestCase
     {
         // set up the anonymous-function-defined service to instantiate
         $id = $this->createMock(Id::class);
-        $definition = function () { return new StdClass(); };
+        $definition = function () {
+            return new StdClass();
+        };
 
         $service = new Fx($id, $definition);
 

--- a/tests/Service/Service/ParseTest.php
+++ b/tests/Service/Service/ParseTest.php
@@ -11,8 +11,10 @@ namespace Jstewmc\Gravity\Service\Service;
 
 use Jstewmc\Gravity\FactoryTest;
 use Jstewmc\Gravity\Id\Data\Service as Id;
-use Jstewmc\Gravity\Manager;
-use Jstewmc\Gravity\Service\Data\{Factory, Fx, Instance, Newable};
+use Jstewmc\Gravity\Service\Data\Factory;
+use Jstewmc\Gravity\Service\Data\Fx;
+use Jstewmc\Gravity\Service\Data\Instance;
+use Jstewmc\Gravity\Service\Data\Newable;
 use Jstewmc\Gravity\Service\Exception\BadDefinition;
 use PHPUnit\Framework\TestCase;
 use StdClass;
@@ -51,7 +53,9 @@ class ParseTest extends TestCase
     public function testInvokeReturnsServiceIfFx(): void
     {
         $id = $this->createMock(Id::class);
-        $definition = function () { return; };
+        $definition = function () {
+            return;
+        };
 
         $expected = new Fx($id, $definition);
         $actual   = (new Parse())($id, $definition);


### PR DESCRIPTION
This PR adds a basic ruleset for code style and introduces a new composer package.

https://github.com/slevomat/coding-standard

Sniffs:
- PSR1
- PSR2: https://www.php-fig.org/psr/psr-2/#3-namespace-and-use-declarations
- Generic.WhiteSpace.DisallowTabIndent: Spaces >Tabs
- Generic.Formatting.NoSpaceAfterCast: Up for debate, rule can be applied in other direction to force a space
- SlevomatCodingStandard.Commenting.EmptyComment: Comments should not be empty
