### PR TITLE
Fix factory

### DIFF
--- a/src/Factory.php
+++ b/src/Factory.php
@@ -25,5 +25,5 @@ interface Factory
      * @return  object
      * @since   0.1.0
      */
-    public function __invoke(Manager $g): object;
+    public function __invoke(Manager $g);
 }

--- a/tests/Factory.php
+++ b/tests/Factory.php
@@ -23,7 +23,7 @@ use StdClass;
  */
 class FactoryTest implements Factory
 {
-    public function __invoke(Manager $g): object
+    public function __invoke(Manager $g): StdClass
     {
         return new StdClass();
     }


### PR DESCRIPTION
Ah, I had declared an `object` return type on the factory's `__invoke()` method. However, PHP's return types are invariant. Even though the `object` represents all objects in [PHP 7.2](https://wiki.php.net/rfc/object-typehint), when a child method extends a parent method, it must match its return type exactly, according to the [return type RFC](https://wiki.php.net/rfc/return_types): 

> The enforcement of the declared return type during inheritance is invariant; this means that when a sub-type overrides a parent method then the return type of the child must exactly match the parent and may not be omitted. If the parent does not declare a return type then the child is allowed to declare one.