### PR TITLE
Fix deprecation warning message

### DIFF
--- a/src/Deprecation/Service/Warn.php
+++ b/src/Deprecation/Service/Warn.php
@@ -50,7 +50,7 @@ class Warn
     {
         $message = "The service, setting, or alias "
             . "'{$deprecation->getId()}' has been deprecated and "
-            . "should be";
+            . "should be ";
 
         if ($deprecation->hasReplacement()) {
             $message .= "replaced with '{$deprecation->getReplacement()}'";


### PR DESCRIPTION
There was no space after the "... should be".