### PR TITLE
Fix bugs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ before_script:
     - travis_retry composer install --no-interaction
 
 script:
-    - vendor/bin/phpcs -n .
+    - vendor/bin/phpcs -n --ignore=./src/uarray_merge_recursive.php .
     - vendor/bin/phpunit --coverage-clover=coverage.xml
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ before_script:
     - travis_retry composer install --no-interaction
 
 script:
-    - vendor/bin/phpcs -n --ignore=./src/uarray_merge_recursive.php .
+    - vendor/bin/phpcs -n .
     - vendor/bin/phpunit --coverage-clover=coverage.xml
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ before_script:
     - travis_retry composer install --no-interaction
 
 script:
-    - vendor/bin/phpcs -n .
+    - vendor/bin/phpcs -n --ignore=./tests/uarray_merge_recursive_test.php .
     - vendor/bin/phpunit --coverage-clover=coverage.xml
 
 after_success:

--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,7 @@
 	"autoload": {
 		"psr-4": {
 			"Jstewmc\\Gravity\\": "src/"
-		}
+		},
+        "files": ["src/uarray_merge_recursive.php"]
 	}
 }

--- a/src/Definition/Data/Definition.php
+++ b/src/Definition/Data/Definition.php
@@ -39,7 +39,7 @@ abstract class Definition
      */
     public function __construct(Id $id)
     {
-        $this->identifier = $id;
+        $this->id = $id;
     }
 
 
@@ -53,6 +53,6 @@ abstract class Definition
      */
     public function getId(): Id
     {
-        return $this->identifier;
+        return $this->id;
     }
 }

--- a/src/Manager.php
+++ b/src/Manager.php
@@ -22,7 +22,6 @@ use Jstewmc\Gravity\Filesystem\Service\Load as LoadFilesystem;
 use Jstewmc\Gravity\Filesystem\Service\Read as ReadFilesystem;
 use Jstewmc\Gravity\Project\Data\Project;
 use Jstewmc\Gravity\Service\Data\Service;
-use Jstewmc\Gravity\Setting\Data\Setting;
 
 /**
  * The Gravity manager

--- a/src/Manager.php
+++ b/src/Manager.php
@@ -12,7 +12,6 @@ namespace Jstewmc\Gravity;
 use Jstewmc\Gravity\Alias\Data\Alias;
 use Jstewmc\Gravity\Alias\Service\Parse as ParseAlias;
 use Jstewmc\Gravity\Definition\Data\Definition;
-use Jstewmc\Gravity\Definition\Data\Service as ServiceDefinition;
 use Jstewmc\Gravity\Definition\Service\Get as GetDefinition;
 use Jstewmc\Gravity\Definition\Service\Parse as ParseDefinition;
 use Jstewmc\Gravity\Deprecation\Data\Deprecation;
@@ -22,6 +21,8 @@ use Jstewmc\Gravity\Filesystem\Service\Find as FindFilesystem;
 use Jstewmc\Gravity\Filesystem\Service\Load as LoadFilesystem;
 use Jstewmc\Gravity\Filesystem\Service\Read as ReadFilesystem;
 use Jstewmc\Gravity\Project\Data\Project;
+use Jstewmc\Gravity\Service\Data\Service;
+use Jstewmc\Gravity\Setting\Data\Setting;
 
 /**
  * The Gravity manager
@@ -224,7 +225,7 @@ class Manager
     {
         $definition = $this->parseDefinition($id, $value);
 
-        if ($definition instanceof ServiceDefinition) {
+        if ($definition instanceof Service) {
             $this->project->addService($definition);
         } else {
             $this->project->addSetting($definition);
@@ -248,10 +249,10 @@ class Manager
     private function bootstrap(): void
     {
         // instantiate the "set-side" services
-        $parseId = new Id\Service\Parse();
+        $parseId = new \Jstewmc\Gravity\Id\Service\Parse();
 
-        $parseService = new Service\Service\Parse();
-        $parseSetting = new Setting\Service\Parse();
+        $parseService = new \Jstewmc\Gravity\Service\Service\Parse();
+        $parseSetting = new \Jstewmc\Gravity\Setting\Service\Parse();
 
         $this->parseAlias       = new ParseAlias($parseId);
         $this->parseDeprecation = new ParseDeprecation($parseId);
@@ -262,18 +263,17 @@ class Manager
         );
 
         // instantiate the cache (for now, just use a hash)
-        $cache = new Cache\Data\Hash();
+        $cache = new \Jstewmc\Gravity\Cache\Data\Hash();
 
         // instantiate the "get-side" services
         $warnDeprecation = new Warn();
 
-        $resolveId = new Id\Service\Resolve($warnDeprecation);
-        $findId    = new Id\Service\Find($parseId, $resolveId);
+        $resolveId = new \Jstewmc\Gravity\Id\Service\Resolve($warnDeprecation);
+        $findId    = new \Jstewmc\Gravity\Id\Service\Find($parseId, $resolveId);
 
-        $instantiateService = new Service\Service\Instantiate($this);
-        $getService         = new Service\Service\Get($instantiateService);
-
-        $getSetting = new Setting\Service\Get();
+        $instantiateService = new \Jstewmc\Gravity\Service\Service\Instantiate($this);
+        $getService         = new \Jstewmc\Gravity\Service\Service\Get($instantiateService);
+        $getSetting         = new \Jstewmc\Gravity\Setting\Service\Get();
 
         $this->getDefinition = new GetDefinition(
             $findId,

--- a/src/Project/Data/Project.php
+++ b/src/Project/Data/Project.php
@@ -108,7 +108,10 @@ class Project
      */
     public function addSetting(Setting $setting): self
     {
-        $this->settings = $this->merge($this->settings, $setting->getArray());
+        $this->settings = uarray_merge_recursive(
+            $this->settings,
+            $setting->getArray()
+        );
 
         return $this;
     }
@@ -242,50 +245,5 @@ class Project
         }
 
         return $settings;
-    }
-
-
-    /* !Private methods */
-
-    /**
-     * Merges two arrays recursively
-     * PHP's native array_merge_recursive() function combines the scalar values
-     * of duplicate string keys into an array instead of overwriting the first
-     * value with the second value.
-     *
-     * @example  PHP's native function
-     *     $a = ["foo" => "bar"];
-     *     $b = ["foo" => "baz"];
-     *     array_merge_recursive($a, $b);  // returns ["foo" => ["bar","baz"]]
-     * I, on the other hand, will merge arrays so that scalar values in the
-     * second array overwrite the values in the first.
-     * @example  merge two arrays recursively
-     *     $a = ["foo" => "bar"];
-     *     $b = ["foo" => "baz"];
-     *     $this->merge($a, $b);  // returns ["foo" => "baz"]
-     * @param   mixed[] $a the first array
-     * @param   mixed[] $b the second array (takes precedence)
-     * @return  mixed[]
-     * @since    0.1.0
-     * @see      http://php.net/manual/en/function.array-merge-recursive.php#92195
-     *                     gabriel dot sobrinho at gmail dot com's commnent on the
-     *                     array_merge_recursive() man page (accessed 11/26/17)
-     * @todo     hmm, what do we do with zero-indexed arrays (see failing test)
-     */
-    private function merge(array $a, array $b): array
-    {
-        // loop through the second array
-        foreach ($b as $k => $v) {
-            // if the value is an array, the key exists in $a, and the value in
-            // $a sn an array, merge it recursively; otherwise, just set it in
-            // $a
-            if (is_array($v) && isset($a[$k]) && is_array($a[$k])) {
-                $a[$k] = ($this)($a[$k], $v);
-            } else {
-                $a[$k] = $v;
-            }
-        }
-
-        return $a;
     }
 }

--- a/src/uarray_merge_recursive.php
+++ b/src/uarray_merge_recursive.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * The file for the custom uarray_merge_recursive function
+ *
+ * @author     Jack Clayton <clayjs0@gmail.com>
+ * @copyright  2018 Jack Clayton
+ * @license    MIT
+ */
+
+/**
+ * Merges two arrays recursively
+ *
+ * PHP's native array_merge_recursive() merges values when the input arrays
+ * have the same string keys. I'll replace the first value with the second.
+ *
+ * @example  PHP's native function
+ *     $a = ["foo" => "bar"];
+ *     $b = ["foo" => "baz"];
+ *     array_merge_recursive($a, $b);  // returns ["foo" => ["bar","baz"]]
+ *
+ * @example  merge two arrays recursively
+ *     $a = ["foo" => "bar"];
+ *     $b = ["foo" => "baz"];
+ *     $this->merge($a, $b);  // returns ["foo" => "baz"]
+ *
+ * @param   mixed[] $a the first array
+ * @param   mixed[] $b the second array (takes precedence)
+ * @return  mixed[]
+ * @since    0.1.0
+ * @see      http://php.net/manual/en/function.array-merge-recursive.php#92195
+ *           gabriel dot sobrinho at gmail dot com's commnent on the
+ *           array_merge_recursive() man page (accessed 11/26/17)
+ */
+function uarray_merge_recursive(array $a, array $b): array
+{
+    // loop through the second array
+    foreach ($b as $k => $v) {
+        // if the value is an array, the key exists in $a, and the value in
+        // $a is an array, merge it recursively; otherwise, just set it in
+        // $a
+        if (is_array($v) && isset($a[$k]) && is_array($a[$k])) {
+            $a[$k] = uarray_merge_recursive($a[$k], $v);
+        } elseif (is_integer($k)) {
+            $a[] = $v;
+        } else {
+            $a[$k] = $v;
+        }
+    }
+
+    return $a;
+}

--- a/tests/ManagerTest.php
+++ b/tests/ManagerTest.php
@@ -10,6 +10,7 @@
 namespace Jstewmc\Gravity;
 
 use PHPUnit\Framework\TestCase;
+use StdClass;
 
 /**
  * Tests for the manager
@@ -61,11 +62,20 @@ class ManagerTest extends TestCase
         return;
     }
 
-    public function testSet(): void
+    public function testSetReturnsSelfIfSetting(): void
     {
         $g = new Manager();
 
         $this->assertSame($g, $g->set('foo.baz.baz', 1));
+
+        return;
+    }
+
+    public function testSetReturnsSelfIfService(): void
+    {
+        $g = new Manager();
+
+        $this->assertSame($g, $g->set('foo\bar\baz', new StdClass()));
 
         return;
     }

--- a/tests/uarray_merge_recursive_test.php
+++ b/tests/uarray_merge_recursive_test.php
@@ -1,0 +1,86 @@
+<?php
+/**
+ * The file for the uarray_merge_recursive tests
+ *
+ * @author     Jack Clayton <clayjs0@gmail.com>
+ * @copyright  2018 Jack Clayton
+ * @license    MIT
+ */
+
+use PHPUnit\Framework\TestCase;
+
+class uarray_merge_recursive_test extends TestCase
+{
+    // test that PHP's function behaves as we expect
+    public function testArrayMergeRecursive(): void
+    {
+        $a = ['foo' => 'bar'];
+        $b = ['foo' => 'baz'];
+
+        $expected = ['foo' => ['bar', 'baz']];
+        $actual   = array_merge_recursive($a, $b);
+
+        $this->assertEquals($expected, $actual);
+
+        return;
+    }
+
+    public function testIfArraysAreEmpty(): void
+    {
+        $this->assertEquals([], uarray_merge_recursive([], []));
+
+        return;
+    }
+
+    public function testIfArraysAreOneDimensional(): void
+    {
+        $a = ['foo' => 'bar'];
+        $b = ['foo' => 'baz'];
+
+        $expected = ['foo' => 'baz'];
+        $actual   = uarray_merge_recursive($a, $b);
+
+        $this->assertEquals($expected, $actual);
+
+        return;
+    }
+
+    public function testIfArraysAreManyDimensional(): void
+    {
+        $a = ['foo' => ['bar' => ['baz' => 'qux']]];
+        $b = ['foo' => ['bar' => ['baz' => 'quux']]];
+
+        $expected = ['foo' => ['bar' => ['baz' => 'quux']]];
+        $actual   = uarray_merge_recursive($a, $b);
+
+        $this->assertEquals($expected, $actual);
+
+        return;
+    }
+
+    public function testIfArraysAreMixedDimensions(): void
+    {
+        $a = ['foo' => 0, 'bar' => 1, 'baz' => 2];
+        $b = ['foo' => ['bar' => ['baz' => 'qux']]];
+
+        $expected = ['foo' => ['bar' => ['baz' => 'qux']], 'bar' => 1, 'baz' => 2];
+        $actual   = uarray_merge_recursive($a, $b);
+
+        $this->assertEquals($expected, $actual);
+
+        return;
+    }
+
+    public function testIfArraysAreZeroIndexed(): void
+    {
+        $a = ['foo' => ['bar', 'baz']];
+        $b = ['foo' => ['qux']];
+
+        $expected = ['foo' => ['bar', 'baz', 'qux']];
+        $actual   = uarray_merge_recursive($a, $b);
+
+        $this->assertEquals($expected, $actual);
+
+        return;
+    }
+}

--- a/tests/uarray_merge_recursive_test.php
+++ b/tests/uarray_merge_recursive_test.php
@@ -6,9 +6,15 @@
  * @copyright  2018 Jack Clayton
  * @license    MIT
  */
+namespace Jstewmc\Gravity;
 
 use PHPUnit\Framework\TestCase;
 
+/**
+ * Tests for the uarray_merge_recursive custom function
+ *
+ * @since  0.1.0
+ */
 class uarray_merge_recursive_test extends TestCase
 {
     // test that PHP's function behaves as we expect


### PR DESCRIPTION
Fixes a few bugs that I discovered while improving the examples:

- I moved the `Project::merge()` method into a custom function. I know it's a little unorthodox. Heck, I've never done it before, and I've been doing this for years. But, frankly that's what it is! I just want to replace PHP's native `array_merge_recursive` function with my own version. I could move the logic into a service, but then a service is dictating how a project stores its settings, which isn't great. I could leave it in the project, but then it's difficult to test, and in my mind, too much complexity for a data object. I could create an `Arr` utility class, but then that class is just a bag of static methods. A custom function seemed like the least worse solution. I also added lots of tests.

- I renamed the `$identifier` propety of the `Definition` object to `id`. Somehow it was missed in the find-in-project-and-replace operation.

- I also fixed the classnames in the `Manager`. I had imported the wrong classname as `ServiceDefinition` class and services couldn't be set correctly. I added tests to make sure we test both service and setting paths in that method.

Closes #3.