### PR TITLE
Fix filesystem-read to ignore dot directories

### DIFF
--- a/src/Filesystem/Service/Read.php
+++ b/src/Filesystem/Service/Read.php
@@ -113,11 +113,11 @@ class Read
         // otherwise, loop through the vendors directory's vendor directories
         foreach (new DirectoryIterator($vendors) as $vendor) {
             // if the item is a vendor directory
-            if ($vendor->isDir()) {
+            if ($vendor->isDir() && ! $vendor->isDot()) {
                 // loop through the vendor directory's package directories
                 foreach (new DirectoryIterator($vendor->getPathname()) as $package) {
                     // if the item is a package directory
-                    if ($package->isDir()) {
+                    if ($package->isDir() && ! $package->isDot()) {
                         // get the package's (expected) gravity directory pathname
                         $gravity = $this->implode(
                             $package->getPathname(),


### PR DESCRIPTION
Ah, apparently, PHP's native `SplFileInfo::isDir()` method returns dot directories (`.` and `..`) as well. We definitely don't want to include those in our recursive filesystem read.