### PR TITLE
Fix parse-service for classes with __invoke()

### DIFF
--- a/src/Service/Service/Parse.php
+++ b/src/Service/Service/Parse.php
@@ -9,6 +9,7 @@
 
 namespace Jstewmc\Gravity\Service\Service;
 
+use Closure;
 use Jstewmc\Gravity\Factory as FactoryInterface;
 use Jstewmc\Gravity\Id\Data\Service as Id;
 use Jstewmc\Gravity\Service\Data\Factory;
@@ -59,13 +60,16 @@ class Parse
     /**
      * Returns true if the service is an anonymous function
      *
+     * Keep in mind, is_callable() will return true if an object implements
+     * the __invoke() method.
+     *
      * @param   mixed $value the value to test
      * @return  bool
      * @since   0.1.0
      */
     private function isFunction($value): bool
     {
-        return is_callable($value);
+        return is_callable($value) && $value instanceof Closure;
     }
 
     /**

--- a/tests/Service/Service/ParseTest.php
+++ b/tests/Service/Service/ParseTest.php
@@ -65,6 +65,28 @@ class ParseTest extends TestCase
         return;
     }
 
+    /**
+     * We had an issue where an object that implemented the __invoke() method
+     * was considered a function, which it's not.
+     */
+    public function testInvokeReturnsServiceIfObjectImplementsInvoke(): void
+    {
+        $id = $this->createMock(Id::class);
+        $definition = new Class {
+            public function __invoke()
+            {
+                return;
+            }
+        };
+
+        $expected = new Instance($id, $definition);
+        $actual   = (new Parse())($id, $definition);
+
+        $this->assertEquals($expected, $actual);
+
+        return;
+    }
+
     public function testInvokeReturnsServiceIfInstance(): void
     {
         $id = $this->createMock(Id::class);


### PR DESCRIPTION
Apparently, when a class implements the `__invoke()` method the `is_callable()` method will return true, which in hindsight makes sense. This caused _factory-defined_ services to be parsed as _function-defined_ services instead.