### PR TITLE
Add menu to docs

### DIFF
--- a/docs/aliasing.md
+++ b/docs/aliasing.md
@@ -1,3 +1,5 @@
+[Home](index.md) | [Identifying](identifying.md) | [Setting](setting.md) | [Getting](getting.md) | [**Aliasing**](aliasing.md) | [Deprecating](deprecating.md)
+
 # Aliasing services and settings
 
 Aliases allow you to use _different_ identifiers for the _same_ service or setting.
@@ -56,3 +58,7 @@ $d = $g->get(Aliasing\Bar::class);
 
 assert($c === $d);
 ```
+
+---
+
+Next up, [deprecating services and setting](deprecating.md)!

--- a/docs/deprecating.md
+++ b/docs/deprecating.md
@@ -1,3 +1,5 @@
+[Home](index.md) | [Identifying](identifying.md) | [Setting](setting.md) | [Getting](getting.md) | [Aliasing](aliasing.md) | [**Deprecating**](deprecating.md)
+
 ## Deprecating services and settings
 
 Deprecations allow you to mark aliases, settings, or services for removal without breaking your users' code. Deprecate them in one version and remove them in the next.
@@ -66,3 +68,7 @@ $g->get(Deprecating\Foo::class);
 $g->get('jstewmc.gravity.example.deprecating.bar');
 $g->get(Deprecating\Bar::class);
 ```
+
+---
+
+That's it! Return [home](index.md) or start [coding](https://github.com/jstewmc/gravity)!

--- a/docs/getting.md
+++ b/docs/getting.md
@@ -1,3 +1,5 @@
+[Home](index.md) | [Identifying](identifying.md) | [Setting](setting.md) | [**Getting**](getting.md) | [Aliasing](aliasing.md) | [Deprecating](deprecating.md)
+
 # Getting services and settings
 
 Use Gravity to get services and settings from yourself or others.
@@ -46,3 +48,7 @@ $b = $g->get(Setting\Qux::class);
 // remember, PHP's === operator compares the object's references in memory
 assert($a === $b);
 ```
+
+---
+
+Next up, [aliasing services and setting](aliasing.md)!

--- a/docs/identifying.md
+++ b/docs/identifying.md
@@ -1,3 +1,5 @@
+[Home](index.md) | [**Identifying**](identifying.md) | [Setting](setting.md) | [Getting](getting.md) | [Aliasing](aliasing.md) | [Deprecating](deprecating.md)
+
 ## Identifying services and settings
 
 Gravity uses a string identifier (aka, an "id") to uniquely identify a service or setting.
@@ -33,3 +35,7 @@ A service identifier should be a fully-qualified classname. It's not a hard and 
 # Setting identifiers
 
 Setting identifiers, on the other hand, are literal strings. They are admittedly a bit cumbersome, because there is no convenient `::class` constant for them. But, we are working on some ideas to make them easier to use, and we welcome your ideas too.
+
+---
+
+Next up, [setting services and setting](setting.md)!

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,3 +1,5 @@
+[**Home**](index.md) | [Identifying](identifying.md) | [Setting](setting.md) | [Getting](getting.md) | [Aliasing](aliasing.md) | [Deprecating](deprecating.md)
+
 # Getting started
 
 Gravity is a framework-agnostic service and configuration manager. It makes it easy to use other people's settings and services in your application.
@@ -18,3 +20,5 @@ Gravity:
 It works the same for configuration settings.
 
 Gravity makes it easy to create and share services and settings.
+
+Get started with [identifying settings and services](identifying.md)!

--- a/docs/setting.md
+++ b/docs/setting.md
@@ -1,3 +1,5 @@
+[Home](index.md) | [Identifying](identifying.md) | [**Setting**](setting.md) | [Getting](getting.md) | [Aliasing](aliasing.md) | [Deprecating](deprecating.md)
+
 # Setting services and settings
 
 Use Gravity to set services and settings for yourself and others.
@@ -237,3 +239,7 @@ $g->set('jstewmc.gravity.example.waldo-three', 3);
 // good
 $g->set('jstewmc.gravity.example.waldo', [1, 2, 3]);
 ```
+
+---
+
+Next up, [getting services and setting](getting.md)!


### PR DESCRIPTION
Hmm, it's a little tough to navigate the docs without a menu. I'm not entirely sure how to set up Jekyll yet (or if it's even possible). So, let's just brute force it for now.