### PR TITLE
Add PSR-11 compliance

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,8 @@
 		}
 	],
 	"require": {
-		"php": "^7.2"
+		"php": "^7.2",
+        "psr/container": "^1"
 	},
 	"require-dev": {
 		"mikey179/vfsstream": "^1.6",

--- a/src/Alias/Exception/NotFound.php
+++ b/src/Alias/Exception/NotFound.php
@@ -10,13 +10,14 @@
 namespace Jstewmc\Gravity\Alias\Exception;
 
 use Jstewmc\Gravity\Id\Data\Id;
+use Psr\Container\NotFoundExceptionInterface;
 
 /**
  * Thrown when an alias is not found
  *
  * @since  0.1.0
  */
-class NotFound extends Exception
+class NotFound extends Exception implements NotFoundExceptionInterface
 {
     /* !Magic methods */
 

--- a/src/Deprecation/Exception/NotFound.php
+++ b/src/Deprecation/Exception/NotFound.php
@@ -9,12 +9,14 @@
 
 namespace Jstewmc\Gravity\Deprecation\Exception;
 
+use Psr\Container\NotFoundExceptionInterface;
+
 /**
  * Thrown when a deprecation is not found
  *
  * @since  0.1.0
  */
-class NotFound extends Exception
+class NotFound extends Exception implements NotFoundExceptionInterface
 {
     // nothing yet
 }

--- a/src/Exception.php
+++ b/src/Exception.php
@@ -10,13 +10,14 @@
 namespace Jstewmc\Gravity;
 
 use Exception as PHPException;
+use Psr\Container\ContainerExceptionInterface;
 
 /**
  * Thrown when an exception occurs in Gravity
  *
  * @since  0.1.0
  */
-abstract class Exception extends PHPException
+abstract class Exception extends PHPException implements ContainerExceptionInterface
 {
     // nothing yet
 }

--- a/src/Service/Exception/NotFound.php
+++ b/src/Service/Exception/NotFound.php
@@ -10,13 +10,14 @@
 namespace Jstewmc\Gravity\Service\Exception;
 
 use Jstewmc\Gravity\Id\Data\Service as Id;
+use Psr\Container\NotFoundExceptionInterface;
 
 /**
  * Thrown when a service can't be found
  *
  * @since  0.1.0
  */
-class NotFound extends Exception
+class NotFound extends Exception implements NotFoundExceptionInterface
 {
     /* !Magic methods */
 

--- a/src/Setting/Exception/NotFound.php
+++ b/src/Setting/Exception/NotFound.php
@@ -11,13 +11,14 @@ namespace Jstewmc\Gravity\Setting\Exception;
 
 use Jstewmc\Gravity\Id\Data\Setting as Id;
 use Jstewmc\Gravity\Exception;
+use Psr\Container\NotFoundExceptionInterface;
 
 /**
  * Thrown when a setting is not found
  *
  * @since  0.1.0
  */
-class NotFound extends Exception
+class NotFound extends Exception implements NotFoundExceptionInterface
 {
     /* !Private properties */
 

--- a/tests/ManagerTest.php
+++ b/tests/ManagerTest.php
@@ -95,7 +95,9 @@ class ManagerTest extends TestCase
     {
         $g = new Manager();
 
-        $g->set('foo\bar\baz', function () { return new StdClass(); });
+        $g->set('foo\bar\baz', function () {
+            return new StdClass();
+        });
 
         $this->assertTrue($g->has('foo\bar\baz'));
 

--- a/tests/ManagerTest.php
+++ b/tests/ManagerTest.php
@@ -62,6 +62,46 @@ class ManagerTest extends TestCase
         return;
     }
 
+    public function testHasReturnsFalseIfSettingDoesNotExist(): void
+    {
+        $g = new Manager();
+
+        $this->assertFalse($g->has('foo.baz.baz'));
+
+        return;
+    }
+
+    public function testHasReturnsFalseIfServiceDoesNotExist(): void
+    {
+        $g = new Manager();
+
+        $this->assertFalse($g->has('foo\bar\baz'));
+
+        return;
+    }
+
+    public function testHasReturnsTrueIfSettingDoesExist(): void
+    {
+        $g = new Manager();
+
+        $g->set('foo.bar.baz', 1);
+
+        $this->assertTrue($g->has('foo.bar.baz'));
+
+        return;
+    }
+
+    public function testHasReturnsTrueIfServiceDoesExist(): void
+    {
+        $g = new Manager();
+
+        $g->set('foo\bar\baz', function () { return new StdClass(); });
+
+        $this->assertTrue($g->has('foo\bar\baz'));
+
+        return;
+    }
+
     public function testSetReturnsSelfIfSetting(): void
     {
         $g = new Manager();


### PR DESCRIPTION
Hmm, well we can't be compliant, because PSR-11's `ConatinerInterface` doesn't include the `string` argument type hint, even though they say "it MUST be a string". 

I'm all in favor of following standards, but I'm not going to water down the code to meet one. I'm keeping our argument type hints and our non-compliance. When they add argument type hints, we can implement the `ContainerInterface`. Otherwise, I believe we're compliant with the spirit of the interface.

Closes #4.