### PR TITLE
Update hash cache

### DIFF
--- a/src/Cache/Data/Cache.php
+++ b/src/Cache/Data/Cache.php
@@ -9,59 +9,65 @@
 
 namespace Jstewmc\Gravity\Cache\Data;
 
-use Jstewmc\Gravity\Id\Data\Id;
+use Jstewmc\Gravity\Cache\Exception\NotFound;
 
 /**
  * A simple cache interface
  *
+ * This cache interface does its best to adhere to PSR-16, Common Interface for
+ * Caching Libraries. However, the PSR does not support argument and return
+ * types, and it adds multiple-item methods, TTL, and default values which are
+ * unnecessary here.
+ *
  * @since  0.1.0
+ * @see    https://www.php-fig.org/psr/psr-16/  PSR-16: Common Interface for
+ *     Caching Libraries (accessed 2018-10-08)
  */
 interface Cache
 {
-    /* !Public methods */
-
     /**
-     * Returns the cached value
+     * Resets the cache
      *
-     * @param   Id  $id  the identifier to get
-     * @return  mixed
-     * @since   0.1.0
-     */
-    public function get(Id $id);
-
-    /**
-     * Returns true if the value is cached
-     *
-     * @param   Id  $id  the identifier to test
      * @return  bool
      * @since   0.1.0
      */
-    public function has(Id $id): bool;
+    public function clear(): bool;
 
     /**
      * Removes a value from the cache if it exists
      *
-     * @param   Id  the identifier to remove
-     * @return  void
+     * @param   string  the key of the cached item to delete
+     * @return  bool
      * @since   0.1.0
      */
-    public function remove(Id $id): void;
+    public function delete(string $key): bool;
 
     /**
-     * Resets the cache
+     * Returns the cached value
      *
-     * @return  void
+     * @param   string  $key  the key of the cached item to get
+     * @return  mixed
+     * @throws  NotFound  if $key does not exist
      * @since   0.1.0
      */
-    public function reset(): void;
+    public function get(string $key);
+
+    /**
+     * Returns true if the value is cached
+     *
+     * @param   string  $key  the key of the cached item
+     * @return  bool
+     * @since   0.1.0
+     */
+    public function has(string $key): bool;
 
     /**
      * Caches a value
      *
-     * @param   Id  $id  the identifier to cache
-     * @param   mixed       $value       the value to cache
-     * @return  self
+     * @param   string  $id     the identifier to cache
+     * @param   mixed   $value  the value to cache
+     * @return  bool
      * @since   0.1.0
      */
-    public function set(Id $id, $value): Cache;
+    public function set(string $key, $value): bool;
 }

--- a/src/Cache/Data/Hash.php
+++ b/src/Cache/Data/Hash.php
@@ -10,7 +10,6 @@
 namespace Jstewmc\Gravity\Cache\Data;
 
 use Jstewmc\Gravity\Cache\Exception\NotFound;
-use Jstewmc\Gravity\Id\Data\Id;
 
 /**
  * A simple hash-based cache
@@ -31,75 +30,75 @@ class Hash implements Cache
     /* !Public methods */
 
     /**
-     * Returns the cached value
+     * Resets the cache
      *
-     * @param   Id  $id  the identifier to get
-     * @return  mixed
-     * @throws  NotFound  if $id does not exist
-     * @since   0.1.0
-     */
-    public function get(Id $id)
-    {
-        if (!$this->has($id)) {
-            throw new NotFound($id);
-        }
-
-        return $this->values[(string)$id];
-    }
-
-    /**
-     * Returns true if the value is cached
-     *
-     * @param   Id  $id  the identifier to test
      * @return  bool
      * @since   0.1.0
      */
-    public function has(Id $id): bool
+    public function clear(): bool
     {
-        return array_key_exists((string)$id, $this->values);
+        $this->values = [];
+
+        return true;
     }
 
     /**
      * Removes a value from the cache
      *
-     * @param   Id  $id
-     * @return  void
+     * @param   string  $key  the key of the cached item to delete
+     * @return  bool
      * @since   0.1.0
      */
-    public function remove(Id $id): void
+    public function delete(string $key): bool
     {
-        if ($this->has($id)) {
-            unset($this->values[(string)$id]);
+        if ($this->has($key)) {
+            unset($this->values[$key]);
         }
 
-        return;
+        return true;
     }
 
     /**
-     * Resets the cache
+     * Returns the cached value
      *
-     * @return  void
+     * @param   string  $key  the key of the cached item to get
+     * @return  mixed
+     * @throws  NotFound  if $key does not exist
      * @since   0.1.0
      */
-    public function reset(): void
+    public function get(string $key)
     {
-        $this->values = [];
+        if (!$this->has($key)) {
+            throw new NotFound($key);
+        }
 
-        return;
+        return $this->values[$key];
+    }
+
+    /**
+     * Returns true if the value is cached
+     *
+     * @param   string  $key  the key of the cached item
+     * @return  bool
+     * @since   0.1.0
+     */
+    public function has(string $key): bool
+    {
+        return array_key_exists($key, $this->values);
     }
 
     /**
      * Caches a value
      *
-     * @param   Id  $id  the identifier to cache
-     * @param   mixed       $value       the value to cache
-     * @return  self
+     * @param   string  $key    the key to cache
+     * @param   mixed   $value  the value to cache
+     * @return  bool
      * @since   0.1.0
      */
-    public function set(Id $id, $value): Cache
+    public function set(string $key, $value): bool
     {
-        $this->values[(string)$id] = $value;
+        $this->values[$key] = $value;
 
-        return $this;
+        return true;
     }
 }

--- a/src/Cache/Exception/NotFound.php
+++ b/src/Cache/Exception/NotFound.php
@@ -22,25 +22,25 @@ class NotFound extends Exception
     /* !Private properties */
 
     /**
-     * @var    Id  the exception's identifier
+     * @var    string  the cache key (i.e., identifier)
      * @since  0.1.0
      */
-    private $id;
+    private $key;
 
-     
+
     /* !Private properties */
 
     /**
      * Called when the exception is constructed
      *
-     * @param  Id  $id  the not found identifier
+     * @param  string  $key  the key of the missing cached item
      * @since  0.1.0
      */
-    public function __construct(Id $id)
+    public function __construct(string $key)
     {
-        $this->identifier = $id;
+        $this->key = $key;
 
-        $this->message = "'$id' not cached";
+        $this->message = "'$key' not cached";
     }
 
 
@@ -49,10 +49,11 @@ class NotFound extends Exception
     /**
      * Returns the missing identifier
      *
-     * @return  Id
+     * @return  string
+     * @since   0.1.0
      */
-    public function getId(): Id
+    public function getKey(): string
     {
-        return $this->identifier;
+        return $this->key;
     }
 }

--- a/src/Cache/Exception/NotFound.php
+++ b/src/Cache/Exception/NotFound.php
@@ -10,7 +10,6 @@
 namespace Jstewmc\Gravity\Cache\Exception;
 
 use Jstewmc\Gravity\Exception;
-use Jstewmc\Gravity\Id\Data\Id;
 
 /**
  * Thrown when an identifier is not cached

--- a/tests/Cache/Data/HashTest.php
+++ b/tests/Cache/Data/HashTest.php
@@ -10,18 +10,49 @@
 namespace Jstewmc\Gravity\Cache\Data;
 
 use Jstewmc\Gravity\Cache\Exception\NotFound;
-use Jstewmc\Gravity\Id\Data\Id;
 use PHPUnit\Framework\TestCase;
 
 /**
  * Tests for a hash-based cache
+ *
+ * Hmm, these are tough to do without creating dependencies between the set(),
+ * get(), and has() methods. But, if we don't, we're not really testing
+ * behavior, just the static return types, which isn't helpful.
  *
  * @since  0.1.0
  * @group  todo
  */
 class HashTest extends TestCase
 {
-    /* get, has, remove, reset, and set */
+    public function testClear(): void
+    {
+        $key = 'foo';
+
+        $cache = new Hash();
+
+        $cache->set($key, 1);
+
+        $this->assertTrue($cache->has($key));
+        $this->assertTrue($cache->clear());
+        $this->assertFalse($cache->has($key));
+
+        return;
+    }
+
+    public function testDelete(): void
+    {
+        $key = 'foo';
+
+        $cache = new Hash();
+
+        $cache->set($key, 1);
+
+        $this->assertTrue($cache->has($key));
+        $this->assertTrue($cache->delete($key));
+        $this->assertFalse($cache->has($key));
+
+        return;
+    }
 
     public function testGetThrowsExceptionIfValueDoesNotExist(): void
     {
@@ -32,40 +63,44 @@ class HashTest extends TestCase
         return;
     }
 
-    /*
-    public function testGet_returnsValue_ifValueDoesExist(): void
+    public function testGetReturnsValueIfValueDoesExist(): void
     {
+        $key   = 'foo';
+        $value = 1;
 
+        $cache = new Hash();
+
+        $cache->set($key, $value);
+
+        $this->assertEquals($value, $cache->get($key));
+
+        return;
     }
 
-    public function testHas_returnsFalse_ifValueDoesNotExist(): void
+    public function testHasReturnsFalseIfKeyDoesNotExist(): void
     {
+        $this->assertFalse((new Hash())->has('foo'));
 
+        return;
     }
 
-    public function testHas_returnsTrue_ifValueDoesExist(): void
+    public function testHasReturnsTrueIfValueDoesExist(): void
     {
+        $cache = new Hash();
 
+        $cache->set('foo', 1);
+
+        $this->assertTrue($cache->has('foo'));
+
+        return;
     }
-
-    public function testRemove(): void
-    {
-
-    }
-
-    public function testReset(): void
-    {
-
-    }
-    */
 
     public function testSet(): void
     {
         $cache = new Hash();
 
-        $id = $this->createMock(Id::class);
-
-        $this->assertSame($cache, $cache->set($id, true));
+        $this->assertTrue($cache->set('foo', true));
+        $this->assertTrue($cache->has('foo'));
 
         return;
     }

--- a/tests/Cache/Data/HashTest.php
+++ b/tests/Cache/Data/HashTest.php
@@ -58,7 +58,7 @@ class HashTest extends TestCase
     {
         $this->expectException(NotFound::class);
 
-        (new Hash())->get($this->createMock(Id::class));
+        (new Hash())->get('foo');
 
         return;
     }

--- a/tests/Cache/Exception/NotFoundTest.php
+++ b/tests/Cache/Exception/NotFoundTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * The file for the not found exception tests
+ * The file for the cache "not found" exception tests
  *
  * @author     Jack Clayton <claysj0@gmail.com>
  * @copyright  2018 Jack Clayton
@@ -19,14 +19,9 @@ use PHPUnit\Framework\TestCase;
  */
 class NotFoundTest extends TestCase
 {
-    public function testGetId(): void
+    public function testGetKey(): void
     {
-        $id = $this->createMock(Id::class);
-
-        $this->assertSame(
-            $id,
-            (new NotFound($id))->getId()
-        );
+        $this->assertSame('foo', (new NotFound('foo'))->getKey());
 
         return;
     }

--- a/tests/Cache/Exception/NotFoundTest.php
+++ b/tests/Cache/Exception/NotFoundTest.php
@@ -9,7 +9,6 @@
 
 namespace Jstewmc\Gravity\Cache\Exception;
 
-use Jstewmc\Gravity\Id\Data\Id;
 use PHPUnit\Framework\TestCase;
 
 /**


### PR DESCRIPTION
I updated the `Cache` interface and the `Hash` implementation to better match the interface defined in [PSR-16: Common Interface for Caching Libraries](https://www.php-fig.org/psr/psr-16/). However, we're not going to implement it. The interface doesn't support argument or return types, and it requires methods and features we'll never use such as TTL, default values, `getMultiple()`, `setMultiple()`, etc.