### PR TITLE
Increase code coverage

### DIFF
--- a/src/Deprecation/Service/Warn.php
+++ b/src/Deprecation/Service/Warn.php
@@ -13,8 +13,6 @@ class Warn
     public function __invoke(Deprecation $deprecation): void
     {
         trigger_error($this->getMessage($deprecation), E_USER_DEPRECATED);
-
-        return;
     }
 
     private function getMessage(Deprecation $deprecation): string

--- a/src/Path/Service/Resolve.php
+++ b/src/Path/Service/Resolve.php
@@ -98,8 +98,8 @@ class Resolve
         $import = $namespace->getImport($path->getFirstSegment());
 
         // shift the first segment off the path (or, alternatively, shift the
-        // last segment off the import's path), because they're shared
-        $path->shiftFirstSegment();
+        // last segment off the import's path), because they're the same
+        $path->shiftSegment();
 
         return $this->merge($import->getPath(), $path);
     }

--- a/tests/Deprecation/Data/ParsedTest.php
+++ b/tests/Deprecation/Data/ParsedTest.php
@@ -6,18 +6,30 @@
 
 namespace Jstewmc\Gravity\Deprecation\Data;
 
-use Jstewmc\Gravity\Deprecation\Exception\Circular;
+use Jstewmc\Gravity\Deprecation\Exception\{Circular, TypeMismatch};
 use Jstewmc\Gravity\Path\Data\{Path, Service, Setting};
 use PHPUnit\Framework\TestCase;
 
 class ParsedTest extends TestCase
 {
-    public function testConstruct()
+    public function testConstructThrowsExceptionIfCircular()
     {
         $this->expectException(Circular::class);
 
         $source      = new Service(['foo', 'bar', 'baz']);
         $destination = new Service(['foo', 'bar', 'baz']);
+
+        new Parsed($source, $destination);
+
+        return;
+    }
+
+    public function testConstructThrowsExceptionIfTypeMismatch()
+    {
+        $this->expectException(TypeMismatch::class);
+
+        $source      = new Service(['foo', 'bar', 'baz']);
+        $destination = new Setting(['foo', 'bar', 'baz']);
 
         new Parsed($source, $destination);
 

--- a/tests/Deprecation/Data/ParsedTest.php
+++ b/tests/Deprecation/Data/ParsedTest.php
@@ -7,7 +7,7 @@
 namespace Jstewmc\Gravity\Deprecation\Data;
 
 use Jstewmc\Gravity\Deprecation\Exception\Circular;
-use Jstewmc\Gravity\Path\Data\Path;
+use Jstewmc\Gravity\Path\Data\{Path, Service, Setting};
 use PHPUnit\Framework\TestCase;
 
 class ParsedTest extends TestCase
@@ -16,7 +16,10 @@ class ParsedTest extends TestCase
     {
         $this->expectException(Circular::class);
 
-        $deprecation = new Read('foo', 'foo');
+        $source      = new Service(['foo', 'bar', 'baz']);
+        $destination = new Service(['foo', 'bar', 'baz']);
+
+        new Parsed($source, $destination);
 
         return;
     }
@@ -25,7 +28,7 @@ class ParsedTest extends TestCase
     {
         $replacement = $this->mockReplacement();
 
-        $deprecation = new Read($this->mockSource(), $replacement);
+        $deprecation = new Parsed($this->mockSource(), $replacement);
 
         $this->assertSame($replacement, $deprecation->getReplacement());
 
@@ -36,7 +39,7 @@ class ParsedTest extends TestCase
     {
         $source = $this->mockSource();
 
-        $deprecation = new Read($source);
+        $deprecation = new Parsed($source);
 
         $this->assertSame($source, $deprecation->getSource());
 
@@ -45,14 +48,14 @@ class ParsedTest extends TestCase
 
     public function testHasReplacement(): void
     {
-        $deprecation = new Read($this->mockSource(), $this->mockReplacement());
+        $deprecation = new Parsed($this->mockSource(), $this->mockReplacement());
 
         $this->assertTrue($deprecation->hasReplacement());
 
         return;
     }
 
-    private function mockReplacement($path = 'bar'): string
+    private function mockReplacement($path = 'bar'): Path
     {
         $replacement = $this->createMock(Path::class);
         $replacement->method('__toString')->willReturn($path);
@@ -60,7 +63,7 @@ class ParsedTest extends TestCase
         return $replacement;
     }
 
-    private function mockSource($path = 'foo'): string
+    private function mockSource($path = 'foo'): Path
     {
         $source = $this->createMock(Path::class);
         $source->method('__toString')->willReturn($path);

--- a/tests/Deprecation/Data/ResolvedTest.php
+++ b/tests/Deprecation/Data/ResolvedTest.php
@@ -19,7 +19,7 @@ class ResolvedTest extends TestCase
         $source      = $this->mockSource();
         $destination = $source;
 
-        $deprecation = new Read($source, $destination);
+        $deprecation = new Resolved($source, $destination);
 
         return;
     }
@@ -28,7 +28,7 @@ class ResolvedTest extends TestCase
     {
         $replacement = $this->mockReplacement();
 
-        $deprecation = new Read($this->mockSource(), $replacement);
+        $deprecation = new Resolved($this->mockSource(), $replacement);
 
         $this->assertSame($replacement, $deprecation->getReplacement());
 
@@ -39,7 +39,7 @@ class ResolvedTest extends TestCase
     {
         $source = $this->mockSource();
 
-        $deprecation = new Read($source);
+        $deprecation = new Resolved($source);
 
         $this->assertSame($source, $deprecation->getSource());
 
@@ -48,14 +48,14 @@ class ResolvedTest extends TestCase
 
     public function testHasReplacement(): void
     {
-        $deprecation = new Read($this->mockSource(), $this->mockReplacement());
+        $deprecation = new Resolved($this->mockSource(), $this->mockReplacement());
 
         $this->assertTrue($deprecation->hasReplacement());
 
         return;
     }
 
-    private function mockReplacement($path = 'bar'): string
+    private function mockReplacement($path = 'bar'): Id
     {
         $replacement = $this->createMock(Id::class);
         $replacement->method('__toString')->willReturn($path);
@@ -63,7 +63,7 @@ class ResolvedTest extends TestCase
         return $replacement;
     }
 
-    private function mockSource($path = 'foo'): string
+    private function mockSource($path = 'foo'): Id
     {
         $source = $this->createMock(Id::class);
         $source->method('__toString')->willReturn($path);

--- a/tests/Id/Data/ServiceTest.php
+++ b/tests/Id/Data/ServiceTest.php
@@ -6,11 +6,22 @@
 
 namespace Jstewmc\Gravity\Id\Data;
 
+use Jstewmc\Gravity\Id\Exception\TooShort;
 use Jstewmc\Gravity\Path\Data\Service as Path;
 use PHPUnit\Framework\TestCase;
 
 class ServiceTest extends TestCase
 {
+    public function testConstructThrowsExceptionIfShort(): void
+    {
+        $this->expectException(TooShort::class);
+
+        $path = $this->createMock(Path::class);
+        $path->method('getLength')->willReturn(1);
+
+        $id = new Service($path);
+    }
+
     public function testToString(): void
     {
         $string = 'foo\bar\baz';

--- a/tests/Id/Data/SettingTest.php
+++ b/tests/Id/Data/SettingTest.php
@@ -6,11 +6,22 @@
 
 namespace Jstewmc\Gravity\Id\Data;
 
+use Jstewmc\Gravity\Id\Exception\TooShort;
 use Jstewmc\Gravity\Path\Data\Setting as Path;
 use PHPUnit\Framework\TestCase;
 
 class SettingTest extends TestCase
 {
+    public function testConstructThrowsExceptionIfShort(): void
+    {
+        $this->expectException(TooShort::class);
+
+        $path = $this->createMock(Path::class);
+        $path->method('getLength')->willReturn(1);
+
+        $id = new Setting($path);
+    }
+
     public function testToString(): void
     {
         $string = 'foo.bar.baz';

--- a/tests/Ns/Data/ParsedTest.php
+++ b/tests/Ns/Data/ParsedTest.php
@@ -6,6 +6,7 @@
 
 namespace Jstewmc\Gravity\Ns\Data;
 
+use Jstewmc\Gravity\Import\Data\Parsed as Import;
 use Jstewmc\Gravity\Import\Exception\NotFound;
 use PHPUnit\Framework\TestCase;
 
@@ -18,6 +19,18 @@ class ParsedTest extends TestCase
         (new Parsed())->getImport('foo');
 
         return;
+    }
+
+    public function testGetImport(): void
+    {
+        $name = 'foo';
+
+        $import = $this->createMock(Import::class);
+        $import->method('getName')->willReturn($name);
+
+        $namespace = (new Parsed())->setImports([$import]);
+
+        $this->assertSame($import, $namespace->getImport($name));
     }
 
     public function testGetImports(): void

--- a/tests/Ns/Service/CloseTest.php
+++ b/tests/Ns/Service/CloseTest.php
@@ -13,8 +13,14 @@ class CloseTest extends TestCase
 {
     public function testInvoke(): void
     {
-        $expected = new Closed();
-        $actual   = (new Close())(new Opened());
+        $opened = $this->createMock(Opened::class);
+        $opened->method('hasName')->willReturn(true);
+        $opened->method('getname')->willReturn('foo');
+        $opened->method('hasImports')->willReturn(true);
+        $opened->method('getImports')->willReturn([]);
+
+        $expected = (new Closed())->setName('foo')->setImports([]);
+        $actual   = (new Close())($opened);
 
         $this->assertEquals($expected, $actual);
     }

--- a/tests/Path/Data/ServiceTest.php
+++ b/tests/Path/Data/ServiceTest.php
@@ -6,10 +6,18 @@
 
 namespace Jstewmc\Gravity\Path\Data;
 
+use Jstewmc\Gravity\Path\Exception\EmptyPath;
 use PHPUnit\Framework\TestCase;
 
 class ServiceTest extends TestCase
 {
+    public function testConstruct(): void
+    {
+        $this->expectException(EmptyPath::class);
+
+        new Service([]);
+    }
+
     public function testToString(): void
     {
         $this->assertEquals(

--- a/tests/Path/Data/SettingTest.php
+++ b/tests/Path/Data/SettingTest.php
@@ -6,10 +6,18 @@
 
 namespace Jstewmc\Gravity\Path\Data;
 
+use Jstewmc\Gravity\Path\Exception\EmptyPath;
 use PHPUnit\Framework\TestCase;
 
 class SettingTest extends TestCase
 {
+    public function testConstruct(): void
+    {
+        $this->expectException(EmptyPath::class);
+
+        new Setting([]);
+    }
+
     public function testToString(): void
     {
         $this->assertEquals(


### PR DESCRIPTION
Let's see if we can't make Codecov a little happier by increasing our code coverage. Along the way, I found a few issues worth fixing: 

- `Deprecation\Data\ParsedTest.php` used a `Read` deprecation, instead of a `Parsed` one
- `Deprecation\Data\ResolvedTest.php` used a `Read` deprecation, instead of a `Resolved` one
- `Path\Service\Resolve.php` used the wrong method name (i.e., `shiftFirstSegment()` instead of `shiftSegment()`)

We still need to figure out how to test the _find-root_ service.