### PR TITLE
Configure Codecov

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,8 @@
+coverage:
+  status:
+    project:
+      default:
+        # basic
+        target: 95
+        threshold: 1
+        base: auto


### PR DESCRIPTION
Codecov is never happy with us, and I think it's because it's coverage target and threshold are too specific. Let's use the codecov.yml file to [configure Codecov](https://docs.codecov.io/docs/commit-status) to a target coverage of 95% and a threshold of 1%. 