### PR TITLE
Update PHPUnit to 8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ composer.lock
 composer.phar
 .idea
 .project
+.phpunit.*

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
 	"require-dev": {
 		"mikey179/vfsstream": "^1.6",
 		"phpunit/phpunit": "^8",
-        "roave/security-advisories": "dev-master",
+		"roave/security-advisories": "dev-master",
 		"slevomat/coding-standard": "^4"
 	},
 	"autoload": {

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,8 @@
 	},
 	"require-dev": {
 		"mikey179/vfsstream": "^1.6",
-		"phpunit/phpunit": "^6",
+		"phpunit/phpunit": "^8",
+        "roave/security-advisories": "dev-master",
 		"slevomat/coding-standard": "^4"
 	},
 	"autoload": {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -7,8 +7,7 @@
          convertNoticesToExceptions="true"
          convertWarningsToExceptions="true"
          processIsolation="false"
-         stopOnFailure="false"
-         syntaxCheck="true">
+         stopOnFailure="false">
     <testsuites>
     	<testsuite name="Tests">
     		<directory suffix=".php">tests</directory>


### PR DESCRIPTION
Gravity can be upgraded to use PHPUnit 8 without any code changes, let's do it!

I'm also adding roave/security-advisories (https://github.com/Roave/SecurityAdvisories) as this package should be required for all libraries.