### PR TITLE
Add requirements

### DIFF
--- a/src/File/Data/Opened.php
+++ b/src/File/Data/Opened.php
@@ -11,6 +11,7 @@ use Jstewmc\Gravity\Definition\Data\Read as Definition;
 use Jstewmc\Gravity\Deprecation\Data\Read as Deprecation;
 use Jstewmc\Gravity\Import\Data\Read as Import;
 use Jstewmc\Gravity\Ns\Data\Opened as Ns;
+use Jstewmc\Gravity\Requirement\Data\Read as Requirement;
 use Jstewmc\Gravity\Script\Data\Opened as Script;
 
 
@@ -41,6 +42,13 @@ class Opened extends File
     public function namespace(string $namespace): self
     {
         $this->namespace->setName($namespace);
+
+        return $this;
+    }
+
+    public function require(string $key, string $description, callable $validator): self
+    {
+        $this->script->addRequirement(new Requirement($key, $description, $validator));
 
         return $this;
     }

--- a/src/Project/Data/Project.php
+++ b/src/Project/Data/Project.php
@@ -15,6 +15,7 @@ use Jstewmc\Gravity\Id\Data\{
     Service as ServiceId,
     Setting as SettingId
 };
+use Jstewmc\Gravity\Requirement\Data\Resolved as Requirement;
 use Jstewmc\Gravity\Root\Data\Root;
 use Jstewmc\Gravity\Service\Data\Service;
 use Jstewmc\Gravity\Service\Exception\NotFound as ServiceNotFound;
@@ -26,6 +27,8 @@ class Project
     private $aliases = [];
 
     private $deprecations = [];
+
+    private $requirements = [];
 
     private $root;
 
@@ -48,6 +51,13 @@ class Project
     public function addDeprecation(Deprecation $deprecation): self
     {
         $this->deprecations[(string)$deprecation->getSource()] = $deprecation;
+
+        return $this;
+    }
+
+    public function addRequirement(Requirement $requirement): self
+    {
+        $this->requirements[(string)$requirement->getKey()] = $requirement;
 
         return $this;
     }
@@ -85,6 +95,11 @@ class Project
         }
 
         return $this->deprecations[(string)$id];
+    }
+
+    public function getRequirements(): array
+    {
+        return $this->requirements;
     }
 
     public function getRoot(): Root

--- a/src/Project/Service/Bootstrap.php
+++ b/src/Project/Service/Bootstrap.php
@@ -16,6 +16,7 @@ use Jstewmc\Gravity\{
     Import,
     Ns,
     Path,
+    Requirement,
     Root,
     Script,
     Service,
@@ -82,6 +83,9 @@ class Bootstrap
         $project->addService($this->getNamespaceParse());
 
         $project->addService($this->getProjectHydrate());
+
+        $project->addService($this->getRequirementParse());
+        $project->addService($this->getRequirementResolve());
 
         $project->addService($this->getScriptClose());
         $project->addService($this->getScriptInterpret());
@@ -392,6 +396,34 @@ class Bootstrap
         return $service;
     }
 
+    private function getRequirementParse(): Service\Data\Service
+    {
+        $segments = ['jstewmc', 'gravity', 'requirement', 'service', 'parse'];
+        $path     = new Path\Data\Service($segments);
+        $id       = new Id\Data\Service($path);
+        $service  = new Service\Data\Fx($id, function () {
+            return new Requirement\Service\Parse(
+                $this->get(Path\Service\Parse::class)
+            );
+        }, $this->namespace);
+
+        return $service;
+    }
+
+    private function getRequirementResolve(): Service\Data\Service
+    {
+        $segments = ['jstewmc', 'gravity', 'requirement', 'service', 'resolve'];
+        $path     = new Path\Data\Service($segments);
+        $id       = new Id\Data\Service($path);
+        $service  = new Service\Data\Fx($id, function () {
+            return new Requirement\Service\Resolve(
+                $this->get(Path\Service\Resolve::class)
+            );
+        }, $this->namespace);
+
+        return $service;
+    }
+
     private function getScriptClose(): Service\Data\Service
     {
         $segments = ['jstewmc', 'gravity', 'script', 'service', 'close'];
@@ -426,7 +458,8 @@ class Bootstrap
             return new Script\Service\Parse(
                 $this->get(Alias\Service\Parse::class),
                 $this->get(Definition\Service\Parse::class),
-                $this->get(Deprecation\Service\Parse::class)
+                $this->get(Deprecation\Service\Parse::class),
+                $this->get(Requirement\Service\Parse::class)
             );
         }, $this->namespace);
 
@@ -442,7 +475,8 @@ class Bootstrap
             return new Script\Service\Resolve(
                 $this->get(Alias\Service\Resolve::class),
                 $this->get(Definition\Service\Resolve::class),
-                $this->get(Deprecation\Service\Resolve::class)
+                $this->get(Deprecation\Service\Resolve::class),
+                $this->get(Requirement\Service\Resolve::class)
             );
         }, $this->namespace);
 

--- a/src/Requirement/Data/Parsed.php
+++ b/src/Requirement/Data/Parsed.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * @copyright  2018 Jack Clayton
+ * @license    MIT
+ */
+
+namespace Jstewmc\Gravity\Requirement\Data;
+
+use Jstewmc\Gravity\Path\Data\Path;
+
+class Parsed extends Requirement
+{
+    public function __construct(Path $key, string $description, callable $validator)
+    {
+        parent::__construct($key, $description, $validator);
+    }
+
+    public function getKey(): Path
+    {
+        return parent::getKey();
+    }
+}

--- a/src/Requirement/Data/Read.php
+++ b/src/Requirement/Data/Read.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * @copyright  2018 Jack Clayton
+ * @license    MIT
+ */
+
+namespace Jstewmc\Gravity\Requirement\Data;
+
+class Read extends Requirement
+{
+    public function __construct(string $key, string $description, callable $validator)
+    {
+        parent::__construct($key, $description, $validator);
+    }
+
+    public function getKey(): string
+    {
+        return parent::getKey();
+    }
+}

--- a/src/Requirement/Data/Requirement.php
+++ b/src/Requirement/Data/Requirement.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * @copyright  2018 Jack Clayton
+ * @license    MIT
+ */
+
+namespace Jstewmc\Gravity\Requirement\Data;
+
+abstract class Requirement
+{
+    private $key;
+
+    private $description;
+
+    private $validator;
+
+    public function __construct($key, string $description, callable $validator)
+    {
+        $this->key         = $key;
+        $this->description = $description;
+        $this->validator   = $validator;
+    }
+
+    public function getDescription(): string
+    {
+        return $this->description;
+    }
+
+    public function getKey()
+    {
+        return $this->key;
+    }
+
+    public function getValidator(): ?callable
+    {
+        return $this->validator;
+    }
+}

--- a/src/Requirement/Data/Resolved.php
+++ b/src/Requirement/Data/Resolved.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * @copyright  2018 Jack Clayton
+ * @license    MIT
+ */
+
+namespace Jstewmc\Gravity\Requirement\Data;
+
+use Jstewmc\Gravity\Id\Data\Id;
+
+class Resolved extends Requirement
+{
+    public function __construct(Id $key, string $description, callable $validator)
+    {
+        parent::__construct($key, $description, $validator);
+    }
+
+    public function getKey(): Id
+    {
+        return parent::getKey();
+    }
+}

--- a/src/Requirement/Service/Parse.php
+++ b/src/Requirement/Service/Parse.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * @copyright  2018 Jack Clayton
+ * @license    MIT
+ */
+
+namespace Jstewmc\Gravity\Requirement\Service;
+
+use Jstewmc\Gravity\Path\Data\Path;
+use Jstewmc\Gravity\Path\Service\Parse as ParsePath;
+use Jstewmc\Gravity\Requirement\Data\{Parsed, Read};
+
+class Parse
+{
+    private $parsePath;
+
+    public function __construct(ParsePath $parsePath)
+    {
+        $this->parsePath = $parsePath;
+    }
+
+    public function __invoke(Read $requirement): Parsed
+    {
+        $key = $this->parsePath($requirement->getKey());
+
+        $requirement = new Parsed(
+            $key,
+            $requirement->getDescription(),
+            $requirement->getValidator()
+        );
+
+        return $requirement;
+    }
+
+    private function parsePath(string $path): Path
+    {
+        return ($this->parsePath)($path);
+    }
+}

--- a/src/Requirement/Service/Resolve.php
+++ b/src/Requirement/Service/Resolve.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * @copyright  2018 Jack Clayton
+ * @license    MIT
+ */
+
+namespace Jstewmc\Gravity\Requirement\Service;
+
+use Jstewmc\Gravity\Id\Data\Id;
+use Jstewmc\Gravity\Ns\Data\Parsed as Ns;
+use Jstewmc\Gravity\Path\Data\Path;
+use Jstewmc\Gravity\Path\Service\Resolve as ResolvePath;
+use Jstewmc\Gravity\Requirement\Data\{Parsed, Resolved};
+
+class Resolve
+{
+    private $resolvePath;
+
+    public function __construct(ResolvePath $resolvePath)
+    {
+        $this->resolvePath = $resolvePath;
+    }
+
+    public function __invoke(Parsed $requirement, Ns $namespace): Resolved
+    {
+        $key = $this->resolvePath($requirement->getKey(), $namespace);
+
+        $requirement = new Resolved(
+            $key,
+            $requirement->getDescription(),
+            $requirement->getValidator()
+        );
+
+        return $requirement;
+    }
+
+    private function resolvePath(Path $path, Ns $namespace): Id
+    {
+        return ($this->resolvePath)($path, $namespace);
+    }
+}

--- a/src/Script/Data/Opened.php
+++ b/src/Script/Data/Opened.php
@@ -9,6 +9,7 @@ namespace Jstewmc\Gravity\Script\Data;
 use Jstewmc\Gravity\Alias\Data\Read as Alias;
 use Jstewmc\Gravity\Definition\Data\Read as Definition;
 use Jstewmc\Gravity\Deprecation\Data\Read as Deprecation;
+use Jstewmc\Gravity\Requirement\Data\Read as Requirement;
 
 class Opened extends Script
 {
@@ -29,6 +30,13 @@ class Opened extends Script
     public function addDeprecation(Deprecation $deprecation): self
     {
         $this->deprecations[] = $deprecation;
+
+        return $this;
+    }
+
+    public function addRequirement(Requirement $requirement): self
+    {
+        $this->requirements[] = $requirement;
 
         return $this;
     }

--- a/src/Script/Data/Script.php
+++ b/src/Script/Data/Script.php
@@ -14,6 +14,8 @@ abstract class Script
 
     protected $deprecations = [];
 
+    protected $requirements = [];
+
     public function getAliases(): array
     {
         return $this->aliases;
@@ -27,6 +29,11 @@ abstract class Script
     public function getDeprecations(): array
     {
         return $this->deprecations;
+    }
+
+    public function getRequirements(): array
+    {
+        return $this->requirements;
     }
 
     public function setAliases(array $aliases): self
@@ -47,6 +54,13 @@ abstract class Script
     {
         $this->deprecations = $deprecations;
 
+        return $this;
+    }
+
+    public function setRequirements(array $requirements): self
+    {
+        $this->requirements = $requirements;
+        
         return $this;
     }
 }

--- a/src/Script/Service/Close.php
+++ b/src/Script/Service/Close.php
@@ -15,6 +15,7 @@ class Close
         return (new Closed())
             ->setAliases($script->getAliases())
             ->setDefinitions($script->getDefinitions())
-            ->setDeprecations($script->getDeprecations());
+            ->setDeprecations($script->getDeprecations())
+            ->setRequirements($script->getRequirements());
     }
 }

--- a/src/Script/Service/Interpret.php
+++ b/src/Script/Service/Interpret.php
@@ -34,6 +34,7 @@ class Interpret
         $script = (new Interpreted())
             ->setAliases($script->getAliases())
             ->setDeprecations($script->getDeprecations())
+            ->setRequirements($script->getRequirements())
             ->setServices($services)
             ->setSettings($settings);
 

--- a/src/Script/Service/Parse.php
+++ b/src/Script/Service/Parse.php
@@ -9,6 +9,7 @@ namespace Jstewmc\Gravity\Script\Service;
 use Jstewmc\Gravity\Alias\Service\Parse as ParseAlias;
 use Jstewmc\Gravity\Definition\Service\Parse as ParseDefinition;
 use Jstewmc\Gravity\Deprecation\Service\Parse as ParseDeprecation;
+use Jstewmc\Gravity\Requirement\Service\Parse as ParseRequirement;
 use Jstewmc\Gravity\Script\Data\{Closed, Parsed};
 
 class Parse
@@ -22,11 +23,13 @@ class Parse
     public function __construct(
         ParseAlias        $parseAlias,
         ParseDefinition   $parseDefinition,
-        ParseDeprecation  $parseDeprecation
+        ParseDeprecation  $parseDeprecation,
+        ParseRequirement  $parseRequirement
     ) {
         $this->parseAlias       = $parseAlias;
         $this->parseDefinition  = $parseDefinition;
         $this->parseDeprecation = $parseDeprecation;
+        $this->parseRequirement = $parseRequirement;
     }
 
     public function __invoke(Closed $script): Parsed
@@ -34,11 +37,13 @@ class Parse
         $aliases      = $this->parseAliases($script->getAliases());
         $definitions  = $this->parseDefinitions($script->getDefinitions());
         $deprecations = $this->parseDeprecations($script->getDeprecations());
+        $requirements = $this->parseRequirements($script->getRequirements());
 
         $script = (new Parsed())
             ->setAliases($aliases)
             ->setDefinitions($definitions)
-            ->setDeprecations($deprecations);
+            ->setDeprecations($deprecations)
+            ->setRequirements($requirements);
 
         return $script;
     }
@@ -68,5 +73,14 @@ class Parse
         }
 
         return $deprecations;
+    }
+
+    private function parseRequirements(array $requirements): array
+    {
+        foreach ($requirements as &$requirement) {
+            $requirement = ($this->parseRequirement)($requirement);
+        }
+
+        return $requirements;
     }
 }

--- a/src/Script/Service/Resolve.php
+++ b/src/Script/Service/Resolve.php
@@ -10,6 +10,7 @@ use Jstewmc\Gravity\Alias\Service\Resolve as ResolveAlias;
 use Jstewmc\Gravity\Definition\Service\Resolve as ResolveDefinition;
 use Jstewmc\Gravity\Deprecation\Service\Resolve as ResolveDeprecation;
 use Jstewmc\Gravity\Ns\Data\Parsed as Ns;
+use Jstewmc\Gravity\Requirement\Service\Resolve as ResolveRequirement;
 use Jstewmc\Gravity\Script\Data\{Parsed, Resolved};
 
 class Resolve
@@ -20,14 +21,18 @@ class Resolve
 
     private $resolveDeprecation;
 
+    private $resolveRequirement;
+
     public function __construct(
         ResolveAlias        $resolveAlias,
         ResolveDefinition   $resolveDefinition,
-        ResolveDeprecation  $resolveDeprecation
+        ResolveDeprecation  $resolveDeprecation,
+        ResolveRequirement  $resolveRequirement
     ) {
         $this->resolveAlias       = $resolveAlias;
         $this->resolveDefinition  = $resolveDefinition;
         $this->resolveDeprecation = $resolveDeprecation;
+        $this->resolveRequirement = $resolveRequirement;
     }
 
     public function __invoke(Parsed $script, Ns $namespace): Resolved
@@ -47,10 +52,16 @@ class Resolve
             $namespace
         );
 
+        $requirements = $this->resolveRequirements(
+            $script->getRequirements(),
+            $namespace
+        );
+
         $script = (new Resolved())
             ->setAliases($aliases)
             ->setDefinitions($definitions)
-            ->setDeprecations($deprecations);
+            ->setDeprecations($deprecations)
+            ->setRequirements($requirements);
 
         return $script;
     }
@@ -80,5 +91,14 @@ class Resolve
         }
 
         return $deprecations;
+    }
+
+    private function resolveRequirements(array $requirements, Ns $namespace): array
+    {
+        foreach ($requirements as $requirement) {
+            $requirement = ($this->resolveRequirement)($requirement, $namespace);
+        }
+
+        return $requirements;
     }
 }

--- a/tests/File/Data/OpenedTest.php
+++ b/tests/File/Data/OpenedTest.php
@@ -67,6 +67,15 @@ class OpenedTest extends TestCase
         $this->assertSame($file, $file->namespace('foo'));
     }
 
+    public function testRequirement(): void
+    {
+        $file = $this->getFile();
+
+        $this->assertSame($file, $file->require('foo', 'bar', function ($value) {
+            return true;
+        }));
+    }
+
     public function testSet(): void
     {
         $file = $this->getFile();

--- a/tests/Project/Data/ProjectTest.php
+++ b/tests/Project/Data/ProjectTest.php
@@ -24,11 +24,18 @@ use PHPUnit\Framework\TestCase;
 
 class ProjectTest extends TestCase
 {
+    private $root;
+
+    public function setUp(): void
+    {
+        $this->root = $this->createMock(Root::class);
+    }
+
     public function testAddAlias(): void
     {
         $alias = $this->createMock(Alias::class);
 
-        $project = new Project($this->mockRoot());
+        $project = new Project($this->root);
 
         $this->assertSame($project, $project->addAlias($alias));
     }
@@ -37,7 +44,7 @@ class ProjectTest extends TestCase
     {
         $deprecation = $this->createMock(Deprecation::class);
 
-        $project = new Project($this->mockRoot());
+        $project = new Project($this->root);
 
         $this->assertSame($project, $project->addDeprecation($deprecation));
     }
@@ -46,7 +53,7 @@ class ProjectTest extends TestCase
     {
         $requirement = $this->createMock(Requirement::class);
 
-        $project = new Project($this->mockRoot());
+        $project = new Project($this->root);
 
         $this->assertSame($project, $project->addRequirement($requirement));
     }
@@ -55,7 +62,7 @@ class ProjectTest extends TestCase
     {
         $service = $this->createMock(Service::class);
 
-        $project = new Project($this->mockRoot());
+        $project = new Project($this->root);
 
         $this->assertSame($project, $project->addService($service));
     }
@@ -65,7 +72,7 @@ class ProjectTest extends TestCase
         $setting = $this->createMock(Setting::class);
         $setting->method('getArray')->willReturn([]);
 
-        $project = new Project($this->mockRoot());
+        $project = new Project($this->root);
 
         $this->assertSame($project, $project->addSetting($setting));
     }
@@ -76,7 +83,7 @@ class ProjectTest extends TestCase
 
         $id = $this->createMock(Id::class);
 
-        (new Project($this->mockRoot()))->getAlias($id);
+        (new Project($this->root))->getAlias($id);
     }
 
     public function testGetAliasReturnsAliasIfDoesExist(): void
@@ -87,7 +94,7 @@ class ProjectTest extends TestCase
         $alias = $this->createMock(Alias::class);
         $alias->method('getSource')->willReturn($id);
 
-        $project = (new Project($this->mockRoot()))->addAlias($alias);
+        $project = (new Project($this->root))->addAlias($alias);
 
         $this->assertSame($alias, $project->getAlias($id));
     }
@@ -98,7 +105,7 @@ class ProjectTest extends TestCase
 
         $id = $this->createMock(Id::class);
 
-        (new Project($this->mockRoot()))->getDeprecation($id);
+        (new Project($this->root))->getDeprecation($id);
     }
 
     public function testGetDeprecationReturnsDeprecationIfDoesExist(): void
@@ -109,19 +116,19 @@ class ProjectTest extends TestCase
         $deprecation = $this->createMock(Deprecation::class);
         $deprecation->method('getSource')->willReturn($id);
 
-        $project = (new Project($this->mockRoot()))->addDeprecation($deprecation);
+        $project = (new Project($this->root))->addDeprecation($deprecation);
 
         $this->assertSame($deprecation, $project->getDeprecation($id));
     }
 
     public function testGetRequirements(): void
     {
-        $this->assertEquals([], (new Project($this->mockRoot()))->getRequirements());
+        $this->assertEquals([], (new Project($this->root))->getRequirements());
     }
 
     public function testGetRoot(): void
     {
-        $root = $this->mockRoot();
+        $root = $this->root;
 
         $this->assertEquals($root, (new Project($root))->getRoot());
     }
@@ -132,7 +139,7 @@ class ProjectTest extends TestCase
 
         $id = $this->createMock(ServiceId::class);
 
-        (new Project($this->mockRoot()))->getService($id);
+        (new Project($this->root))->getService($id);
     }
 
     public function testGetServiceReturnsServiceIfDoesExist(): void
@@ -143,7 +150,7 @@ class ProjectTest extends TestCase
         $service = $this->createMock(Service::class);
         $service->method('getId')->willReturn($id);
 
-        $project = (new Project($this->mockRoot()))->addService($service);
+        $project = (new Project($this->root))->addService($service);
 
         $this->assertSame($service, $project->getService($id));
     }
@@ -155,7 +162,7 @@ class ProjectTest extends TestCase
         $id = $this->createMock(SettingId::class);
         $id->method('getSegments')->willReturn(['foo', 'bar', 'baz']);
 
-        (new Project($this->mockRoot()))->getSetting($id);
+        (new Project($this->root))->getSetting($id);
     }
 
     public function testGetSettingReturnsSettingIfDoesExist(): void
@@ -168,7 +175,7 @@ class ProjectTest extends TestCase
         $setting->method('getId')->willReturn($id);
         $setting->method('getArray')->willReturn(['foo' => ['bar' => ['baz' => 1]]]);
 
-        $project = (new Project($this->mockRoot()))->addSetting($setting);
+        $project = (new Project($this->root))->addSetting($setting);
 
         $this->assertEquals(1, $project->getSetting($id));
     }
@@ -177,7 +184,7 @@ class ProjectTest extends TestCase
     {
         $id = $this->createMock(Id::class);
 
-        $this->assertFalse((new Project($this->mockRoot()))->hasAlias($id));
+        $this->assertFalse((new Project($this->root))->hasAlias($id));
 
         return;
     }
@@ -190,7 +197,7 @@ class ProjectTest extends TestCase
         $alias = $this->createMock(Alias::class);
         $alias->method('getSource')->willReturn($id);
 
-        $project = (new Project($this->mockRoot()))->addAlias($alias);
+        $project = (new Project($this->root))->addAlias($alias);
 
         $this->assertTrue($project->hasAlias($id));
     }
@@ -199,7 +206,7 @@ class ProjectTest extends TestCase
     {
         $id = $this->createMock(Id::class);
 
-        $this->assertFalse((new Project($this->mockRoot()))->hasDeprecation($id));
+        $this->assertFalse((new Project($this->root))->hasDeprecation($id));
     }
 
     public function testHasDeprecationReturnsTrueIfDoesExist(): void
@@ -210,7 +217,7 @@ class ProjectTest extends TestCase
         $deprecation = $this->createMock(Deprecation::class);
         $deprecation->method('getSource')->willReturn($id);
 
-        $project = (new Project($this->mockRoot()))->addDeprecation($deprecation);
+        $project = (new Project($this->root))->addDeprecation($deprecation);
 
         $this->assertTrue($project->hasDeprecation($id));
     }
@@ -219,7 +226,7 @@ class ProjectTest extends TestCase
     {
         $id = $this->createMock(Id::class);
 
-        $this->assertFalse((new Project($this->mockRoot()))->hasService($id));
+        $this->assertFalse((new Project($this->root))->hasService($id));
     }
 
     public function testHasServiceReturnsTrueIfDoesExist(): void
@@ -230,7 +237,7 @@ class ProjectTest extends TestCase
         $service = $this->createMock(Service::class);
         $service->method('getId')->willReturn($id);
 
-        $project = (new Project($this->mockRoot()))->addService($service);
+        $project = (new Project($this->root))->addService($service);
 
         $this->assertTrue($project->hasService($id));
     }
@@ -240,7 +247,7 @@ class ProjectTest extends TestCase
         $id = $this->createMock(Id::class);
         $id->method('getSegments')->willReturn(['foo', 'bar', 'baz']);
 
-        $this->assertFalse((new Project($this->mockRoot()))->hasSetting($id));
+        $this->assertFalse((new Project($this->root))->hasSetting($id));
     }
 
     public function testHasSettingReturnsTrueIfDoesExist(): void
@@ -256,13 +263,8 @@ class ProjectTest extends TestCase
         $setting->method('getId')->willReturn($id);
         $setting->method('getArray')->willReturn(['foo' => ['bar' => ['baz' => 1]]]);
 
-        $project = (new Project($this->mockRoot()))->addSetting($setting);
+        $project = (new Project($this->root))->addSetting($setting);
 
         $this->assertTrue($project->hasSetting($id));
-    }
-
-    private function mockRoot(): Root
-    {
-        return $this->createMock(Root::class);
     }
 }

--- a/tests/Project/Data/ProjectTest.php
+++ b/tests/Project/Data/ProjectTest.php
@@ -14,6 +14,7 @@ use Jstewmc\Gravity\Id\Data\Id;
 use Jstewmc\Gravity\Id\Data\Service as ServiceId;
 use Jstewmc\Gravity\Id\Data\Setting as SettingId;
 use Jstewmc\Gravity\Path\Data\Setting as SettingPath;
+use Jstewmc\Gravity\Requirement\Data\Resolved as Requirement;
 use Jstewmc\Gravity\Root\Data\Root;
 use Jstewmc\Gravity\Service\Data\Service;
 use Jstewmc\Gravity\Service\Exception\NotFound as ServiceNotFound;
@@ -39,6 +40,15 @@ class ProjectTest extends TestCase
         $project = new Project($this->mockRoot());
 
         $this->assertSame($project, $project->addDeprecation($deprecation));
+    }
+
+    public function testAddRequirement(): void
+    {
+        $requirement = $this->createMock(Requirement::class);
+
+        $project = new Project($this->mockRoot());
+
+        $this->assertSame($project, $project->addRequirement($requirement));
     }
 
     public function testAddService(): void
@@ -102,6 +112,18 @@ class ProjectTest extends TestCase
         $project = (new Project($this->mockRoot()))->addDeprecation($deprecation);
 
         $this->assertSame($deprecation, $project->getDeprecation($id));
+    }
+
+    public function testGetRequirements(): void
+    {
+        $this->assertEquals([], (new Project($this->mockRoot()))->getRequirements());
+    }
+
+    public function testGetRoot(): void
+    {
+        $root = $this->mockRoot();
+
+        $this->assertEquals($root, (new Project($root))->getRoot());
     }
 
     public function testGetServiceThrowsExceptionIfDoesNotExist(): void

--- a/tests/Requirement/Data/ParsedTest.php
+++ b/tests/Requirement/Data/ParsedTest.php
@@ -13,7 +13,7 @@ class ParsedTest extends TestCase
 {
     private $key;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->key = $this->createMock(Path::class);
     }

--- a/tests/Requirement/Data/ParsedTest.php
+++ b/tests/Requirement/Data/ParsedTest.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * @copyright  2018 Jack Clayton
+ * @license    MIT
+ */
+
+namespace Jstewmc\Gravity\Requirement\Data;
+
+use Jstewmc\Gravity\Path\Data\Path;
+use PHPUnit\Framework\TestCase;
+
+class ParsedTest extends TestCase
+{
+    private $key;
+
+    public function setUp()
+    {
+        $this->key = $this->createMock(Path::class);
+    }
+
+    public function testGetDescription(): void
+    {
+        $description = 'bar';
+
+        $requirement = new Parsed($this->key, $description, function ($value) {
+            return true;
+        });
+
+        $this->assertEquals($description, $requirement->getDescription());
+    }
+
+    public function testGetKey(): void
+    {
+        $requirement = new Parsed($this->key, 'bar', function ($value) {
+            return true;
+        });
+
+        $this->assertSame($this->key, $requirement->getKey());
+    }
+
+    public function testGetValidator(): void
+    {
+        $validator = function ($value) {
+            return true;
+        };
+
+        $requirement = new Parsed($this->key, 'bar', $validator);
+
+        $this->assertEquals($validator, $requirement->getValidator());
+    }
+}

--- a/tests/Requirement/Data/ReadTest.php
+++ b/tests/Requirement/Data/ReadTest.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * @copyright  2018 Jack Clayton
+ * @license    MIT
+ */
+
+namespace Jstewmc\Gravity\Requirement\Data;
+
+use PHPUnit\Framework\TestCase;
+
+class ReadTest extends TestCase
+{
+    public function testGetDescription(): void
+    {
+        $description = 'bar';
+
+        $requirement = new Read('foo', $description, function ($value) {
+            return true;
+        });
+
+        $this->assertEquals($description, $requirement->getDescription());
+    }
+
+    public function testGetKey(): void
+    {
+        $key = 'foo';
+
+        $requirement = new Read($key, 'bar', function ($value) {
+            return true;
+        });
+
+        $this->assertEquals($key, $requirement->getKey());
+    }
+
+    public function testGetValidator(): void
+    {
+        $validator = function ($value) {
+            return true;
+        };
+
+        $requirement = new Read('foo', 'bar', $validator);
+
+        $this->assertEquals($validator, $requirement->getValidator());
+    }
+}

--- a/tests/Requirement/Data/ResolvedTest.php
+++ b/tests/Requirement/Data/ResolvedTest.php
@@ -13,7 +13,7 @@ class ResolvedTest extends TestCase
 {
     private $key;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->key = $this->createMock(Id::class);
     }

--- a/tests/Requirement/Data/ResolvedTest.php
+++ b/tests/Requirement/Data/ResolvedTest.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * @copyright  2018 Jack Clayton
+ * @license    MIT
+ */
+
+namespace Jstewmc\Gravity\Requirement\Data;
+
+use Jstewmc\Gravity\Id\Data\Id;
+use PHPUnit\Framework\TestCase;
+
+class ResolvedTest extends TestCase
+{
+    private $key;
+
+    public function setUp()
+    {
+        $this->key = $this->createMock(Id::class);
+    }
+
+    public function testGetDescription(): void
+    {
+        $description = 'bar';
+
+        $requirement = new Resolved($this->key, $description, function ($value) {
+            return true;
+        });
+
+        $this->assertEquals($description, $requirement->getDescription());
+    }
+
+    public function testGetKey(): void
+    {
+        $requirement = new Resolved($this->key, 'bar', function ($value) {
+            return true;
+        });
+
+        $this->assertSame($this->key, $requirement->getKey());
+    }
+
+    public function testGetValidator(): void
+    {
+        $validator = function ($value) {
+            return true;
+        };
+
+        $requirement = new Resolved($this->key, 'bar', $validator);
+
+        $this->assertEquals($validator, $requirement->getValidator());
+    }
+}

--- a/tests/Requirement/Service/ParseTest.php
+++ b/tests/Requirement/Service/ParseTest.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * @copyright  2018 Jack Clayton
+ * @license    MIT
+ */
+
+namespace Jstewmc\Gravity\Requirement\Service;
+
+use Jstewmc\Gravity\Path\Data\Path;
+use Jstewmc\Gravity\Path\Service\Parse as ParsePath;
+use Jstewmc\Gravity\Requirement\Data\{Parsed, Read};
+use PHPUnit\Framework\TestCase;
+
+class ParseTest extends TestCase
+{
+    public function testInvoke(): void
+    {
+        // set up the path to return
+        $key = $this->createMock(Path::class);
+        $key->method('__toString')->willReturn('foo\bar\baz');
+
+        // stub the parse-path service to return the stubs above
+        $parsePath = $this->createMock(ParsePath::class);
+        $parsePath->method('__invoke')->willReturn($key);
+
+        // instantiate the system under test
+        $sut = new Parse($parsePath);
+
+        // stub a read requirement for input
+        $description = 'foo';
+        $validator   = function ($value) {
+            return true;
+        };
+
+        $requirement = $this->createMock(Read::class);
+        $requirement->method('getDescription')->willReturn($description);
+        $requirement->method('getValidator')->willReturn($validator);
+
+        // set expectations and get result
+        $expected = new Parsed($key, $description, $validator);
+        $actual   = $sut($requirement);
+
+        $this->assertEquals($expected, $actual);
+
+        return;
+    }
+}

--- a/tests/Requirement/Service/ResolveTest.php
+++ b/tests/Requirement/Service/ResolveTest.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * @copyright  2018 Jack Clayton
+ * @license    MIT
+ */
+
+namespace Jstewmc\Gravity\Requirement\Service;
+
+use Jstewmc\Gravity\Id\Data\Id;
+use Jstewmc\Gravity\Ns\Data\Parsed as Ns;
+use Jstewmc\Gravity\Path\Service\Resolve as ResolvePath;
+use Jstewmc\Gravity\Requirement\Data\{Parsed, Resolved};
+use PHPUnit\Framework\TestCase;
+
+class ResolveTest extends TestCase
+{
+    public function testInvoke(): void
+    {
+        // stub the resolve-path service
+        $key = $this->createMock(Id::class);
+        $key->method('__toString')->willReturn('foo\bar\baz');
+
+        $resolvePath = $this->createMock(ResolvePath::class);
+        $resolvePath->method('__invoke')->willReturn($key);
+
+        // instantiate the system under test
+        $sut = new Resolve($resolvePath);
+
+        // stub a parsed requirement for input
+        $description = 'foo';
+        $validator   = function ($value) {
+            return true;
+        };
+
+        $requirement = $this->createMock(Parsed::class);
+        $requirement->method('getDescription')->willReturn($description);
+        $requirement->method('getValidator')->willReturn($validator);
+
+        $expected = new Resolved($key, $description, $validator);
+        $actual   = $sut($requirement, $this->createMock(Ns::class));
+
+        $this->assertEquals($expected, $actual);
+
+        return;
+    }
+}

--- a/tests/Script/Data/ClosedTest.php
+++ b/tests/Script/Data/ClosedTest.php
@@ -25,6 +25,11 @@ class ClosedTest extends TestCase
         $this->assertEquals([], (new Closed())->getDeprecations());
     }
 
+    public function testGetRequirements(): void
+    {
+        $this->assertEquals([], (new Closed())->getRequirements());
+    }
+
     public function testSetAliases(): void
     {
         $script = new Closed();
@@ -44,5 +49,12 @@ class ClosedTest extends TestCase
         $script = new Closed();
 
         $this->assertSame($script, $script->setDeprecations([]));
+    }
+
+    public function testSetRequirements(): void
+    {
+        $script = new Closed();
+
+        $this->assertSame($script, $script->setRequirements([]));
     }
 }

--- a/tests/Script/Data/InterpretedTest.php
+++ b/tests/Script/Data/InterpretedTest.php
@@ -25,6 +25,11 @@ class InterpretedTest extends TestCase
         $this->assertEquals([], (new Interpreted())->getDeprecations());
     }
 
+    public function testGetRequirements(): void
+    {
+        $this->assertEquals([], (new Interpreted())->getRequirements());
+    }
+
     public function testGetServices(): void
     {
         $this->assertEquals([], (new Interpreted())->getServices());
@@ -54,6 +59,13 @@ class InterpretedTest extends TestCase
         $script = new Interpreted();
 
         $this->assertSame($script, $script->setDeprecations([]));
+    }
+
+    public function testSetRequirements(): void
+    {
+        $script = new Interpreted();
+
+        $this->assertSame($script, $script->setRequirements([]));
     }
 
     public function testSetServices(): void

--- a/tests/Script/Data/OpenedTest.php
+++ b/tests/Script/Data/OpenedTest.php
@@ -9,6 +9,7 @@ namespace Jstewmc\Gravity\Script\Data;
 use Jstewmc\Gravity\Alias\Data\Read as Alias;
 use Jstewmc\Gravity\Definition\Data\Read as Definition;
 use Jstewmc\Gravity\Deprecation\Data\Read as Deprecation;
+use Jstewmc\Gravity\Requirement\Data\Read as Requirement;
 use PHPUnit\Framework\TestCase;
 
 class OpenedTest extends TestCase
@@ -40,6 +41,15 @@ class OpenedTest extends TestCase
         $this->assertSame($script, $script->addDeprecation($deprecation));
     }
 
+    public function testAddRequirement(): void
+    {
+        $script = new Opened();
+
+        $requirement = $this->createMock(Requirement::class);
+
+        $this->assertSame($script, $script->addRequirement($requirement));
+    }
+
     public function testGetAliases(): void
     {
         $this->assertEquals([], (new Opened())->getAliases());
@@ -53,6 +63,11 @@ class OpenedTest extends TestCase
     public function testGetDeprecations(): void
     {
         $this->assertEquals([], (new Opened())->getDeprecations());
+    }
+
+    public function testGetRequirements(): void
+    {
+        $this->assertEquals([], (new Opened())->getRequirements());
     }
 
     public function testSetAliases(): void
@@ -74,5 +89,12 @@ class OpenedTest extends TestCase
         $script = new Opened();
 
         $this->assertSame($script, $script->setDeprecations([]));
+    }
+
+    public function testSetRequirements(): void
+    {
+        $script = new Opened();
+
+        $this->assertSame($script, $script->setRequirements([]));
     }
 }

--- a/tests/Script/Data/ParsedTest.php
+++ b/tests/Script/Data/ParsedTest.php
@@ -25,6 +25,11 @@ class ParsedTest extends TestCase
         $this->assertEquals([], (new Parsed())->getDeprecations());
     }
 
+    public function testGetRequirements(): void
+    {
+        $this->assertEquals([], (new Parsed())->getRequirements());
+    }
+
     public function testSetAliases(): void
     {
         $script = new Parsed();
@@ -44,5 +49,12 @@ class ParsedTest extends TestCase
         $script = new Parsed();
 
         $this->assertSame($script, $script->setDeprecations([]));
+    }
+
+    public function testSetRequirements(): void
+    {
+        $script = new Parsed();
+
+        $this->assertSame($script, $script->setRequirements([]));
     }
 }

--- a/tests/Script/Data/ResolvedTest.php
+++ b/tests/Script/Data/ResolvedTest.php
@@ -25,6 +25,11 @@ class ResolvedTest extends TestCase
         $this->assertEquals([], (new Resolved())->getDeprecations());
     }
 
+    public function testGetRequirements(): void
+    {
+        $this->assertEquals([], (new Resolved())->getRequirements());
+    }
+
     public function testSetAliases(): void
     {
         $script = new Resolved();
@@ -44,5 +49,12 @@ class ResolvedTest extends TestCase
         $script = new Resolved();
 
         $this->assertSame($script, $script->setDeprecations([]));
+    }
+
+    public function testSetRequirements(): void
+    {
+        $script = new Resolved();
+
+        $this->assertSame($script, $script->setRequirements([]));
     }
 }

--- a/tests/Script/Service/ParseTest.php
+++ b/tests/Script/Service/ParseTest.php
@@ -9,6 +9,7 @@ namespace Jstewmc\Gravity\Script\Service;
 use Jstewmc\Gravity\Alias\Service\Parse as ParseAlias;
 use Jstewmc\Gravity\Definition\Service\Parse as ParseDefinition;
 use Jstewmc\Gravity\Deprecation\Service\Parse as ParseDeprecation;
+use Jstewmc\Gravity\Requirement\Service\Parse as ParseRequirement;
 use Jstewmc\Gravity\Script\Data\{Closed, Parsed};
 use PHPUnit\Framework\TestCase;
 
@@ -19,8 +20,14 @@ class ParseTest extends TestCase
         $parseAlias       = $this->createMock(ParseAlias::class);
         $parseDefinition  = $this->createMock(ParseDefinition::class);
         $parseDeprecation = $this->createMock(ParseDeprecation::class);
+        $parseRequirement = $this->createMock(ParseRequirement::class);
 
-        $sut = new Parse($parseAlias, $parseDefinition, $parseDeprecation);
+        $sut = new Parse(
+            $parseAlias,
+            $parseDefinition,
+            $parseDeprecation,
+            $parseRequirement
+        );
 
         $this->assertEquals(new Parsed(), $sut(new Closed()));
     }

--- a/tests/Script/Service/ResolveTest.php
+++ b/tests/Script/Service/ResolveTest.php
@@ -10,6 +10,7 @@ use Jstewmc\Gravity\Alias\Service\Resolve as ResolveAlias;
 use Jstewmc\Gravity\Definition\Service\Resolve as ResolveDefinition;
 use Jstewmc\Gravity\Deprecation\Service\Resolve as ResolveDeprecation;
 use Jstewmc\Gravity\Ns\Data\Parsed as Ns;
+use Jstewmc\Gravity\Requirement\Service\Resolve as ResolveRequirement;
 use Jstewmc\Gravity\Script\Data\{Parsed, Resolved};
 use PHPUnit\Framework\TestCase;
 
@@ -20,11 +21,13 @@ class ResolveTest extends TestCase
         $resolveAlias       = $this->createMock(ResolveAlias::class);
         $resolveDefinition  = $this->createMock(ResolveDefinition::class);
         $resolveDeprecation = $this->createMock(ResolveDeprecation::class);
+        $resolveRequirement = $this->createMock(ResolveRequirement::class);
 
         $sut = new Resolve(
             $resolveAlias,
             $resolveDefinition,
-            $resolveDeprecation
+            $resolveDeprecation,
+            $resolveRequirement
         );
 
         $this->assertEquals(new Resolved(), $sut(new Parsed(), new Ns()));


### PR DESCRIPTION
Add `Requirement` as a top-level object to a `Script` and `Project`. It transitions from read, to parsed, to resolved like an alias, deprecation, and definition. 

You can define a new project requirement using `$g->require()`. 

I'll wait to update the docs until after #8, when you can actually use the requirements to do something haha. 

Closes #13.