### PR TITLE
Add validation

### DIFF
--- a/.gravity/examples/setting.php
+++ b/.gravity/examples/setting.php
@@ -3,24 +3,28 @@
  * @copyright  2018 Jack Clayton
  * @license    MIT
  */
- 
+
 namespace Jstewmc\Gravity\Example;
 
 // define a service using null
 $g->set(Service\Baz::class);
 
 // define a service using an instance
-$g->set(Setting\Qux::class, new Service\Qux());
+$g->set(Service\Qux::class, new Service\Qux());
 
-// define a service using an aonoymous function
-$g->set(Setting\Quux::class, function (): Quux {
-    return new Quux();
+// define a service using an anonymous function
+$g->set(Service\Quux::class, function (): Service\Quux {
+    return new Service\Quux();
 });
 
-$g->set(Setting\Corge::class, function (): Service\Corge {
-    $quux = $this->get(Setting\Quux::class);
+// define a service with the same classname (and no arguments)
+$g->set(Service\Quuz::class);
 
-    return new Corge($quux);
+// inject other services
+$g->set(Service\Corge::class, function (): Service\Corge {
+    $quux = $this->get(Service\Quuz::class);
+
+    return new Service\Corge($quux);
 });
 
 // define a service using a factory

--- a/composer.json
+++ b/composer.json
@@ -25,5 +25,8 @@
 			"Jstewmc\\Gravity\\Example\\": "examples/src/"
 		},
         "files": ["src/uarray_merge_recursive.php"]
-	}
+	},
+    "bin": [
+        "gravity"
+    ]
 }

--- a/examples/getting.php
+++ b/examples/getting.php
@@ -15,12 +15,12 @@ $actual   = $g->get('jstewmc.gravity.example.setting.foo');
 assert($expected == $actual);
 
 // using the settings from ../.gravity/examples/setting.php:12
-$instance = $g->get(Setting\Qux::class);
+$instance = $g->get(Service\Qux::class);
 
 assert($instance instanceof Service\Qux);
 
-$a = $g->get(Setting\Qux::class);
-$b = $g->get(Setting\Qux::class);
+$a = $g->get(Service\Qux::class);
+$b = $g->get(Service\Qux::class);
 
 // remember, PHP's === operator compares the object's references in memory
 assert($a === $b);

--- a/gravity
+++ b/gravity
@@ -1,0 +1,63 @@
+#!/usr/bin/env php
+<?php
+/*
+ * @copyright  2018 Jack Clayton
+ * @license    MIT
+ */
+
+use Jstewmc\Gravity\Gravity;
+use Jstewmc\Gravity\Project\Service\Validate;
+
+// require Composer's autoload or die
+$pathnames = [
+    __DIR__ . '/../../autoload.php',
+    __DIR__ . '/../vendor/autoload.php',
+    __DIR__ . '/vendor/autoload.php'
+];
+
+foreach ($pathnames as $pathname) {
+    if (file_exists($pathname)) {
+        break;
+    }
+}
+
+if (isset($pathname)) {
+    require_once $pathname;
+} else {
+    fwrite(
+        STDERR,
+        'You need to set up the project dependencies using Composer:' . PHP_EOL . PHP_EOL .
+        '    composer install' . PHP_EOL . PHP_EOL .
+        'You can learn all about Composer on https://getcomposer.org/.' . PHP_EOL
+    );
+
+    die(1);
+}
+
+// execute command
+$command = $argv[1];
+
+if ($command === 'validate') {
+    $g = (new Gravity())->pull();
+
+    $errors = $g->get(Validate::class)($g->getProject(), $g);
+
+    if (count($errors) === 0) {
+        fwrite(STDOUT, "Project is valid!" . PHP_EOL);
+
+        exit(0);
+    } else {
+        $total = count($errors);
+
+        fwrite(
+            STDOUT,
+            "Project is invalid! Found {$total} errors:" . PHP_EOL . PHP_EOL
+        );
+
+        foreach ($errors as $key => $error) {
+            echo "    * {$key}: {$error}" . PHP_EOL . PHP_EOL;
+        }
+
+        exit(1);
+    }
+}

--- a/gravity
+++ b/gravity
@@ -50,12 +50,12 @@ if ($command === 'validate') {
         $total = count($errors);
 
         fwrite(
-            STDOUT,
+            STDERR,
             "Project is invalid! Found {$total} errors:" . PHP_EOL . PHP_EOL
         );
 
         foreach ($errors as $key => $error) {
-            echo "    * {$key}: {$error}" . PHP_EOL . PHP_EOL;
+            fwrite(STDERR, "    * {$key}: {$error}" . PHP_EOL . PHP_EOL);
         }
 
         exit(1);

--- a/src/Manager/Data/Manager.php
+++ b/src/Manager/Data/Manager.php
@@ -70,6 +70,11 @@ class Manager
         return $value;
     }
 
+    public function getProject(): Project
+    {
+        return $this->project;
+    }
+
     public function has(string $path): bool
     {
         $id = $this->getId($path);

--- a/src/Project/Data/Project.php
+++ b/src/Project/Data/Project.php
@@ -116,6 +116,11 @@ class Project
         return $this->services[(string)$id];
     }
 
+    public function getServices(): array
+    {
+        return $this->services;
+    }
+
     public function getSetting(SettingId $id)
     {
         if (!$this->hasSetting($id)) {

--- a/src/Project/Service/Bootstrap.php
+++ b/src/Project/Service/Bootstrap.php
@@ -83,6 +83,7 @@ class Bootstrap
         $project->addService($this->getNamespaceParse());
 
         $project->addService($this->getProjectHydrate());
+        $project->addService($this->getProjectValidate());
 
         $project->addService($this->getRequirementParse());
         $project->addService($this->getRequirementResolve());
@@ -392,6 +393,20 @@ class Bootstrap
         $path     = new Path\Data\Service($segments);
         $id       = new Id\Data\Service($path);
         $service  = new Service\Data\Newable($id);
+
+        return $service;
+    }
+
+    private function getProjectValidate(): Service\Data\Service
+    {
+        $segments = ['jstewmc', 'gravity', 'project', 'service', 'validate'];
+        $path     = new Path\Data\Service($segments);
+        $id       = new Id\Data\Service($path);
+        $service  = new Service\Data\Fx($id, function () {
+            return new \Jstewmc\Gravity\Project\Service\Validate(
+                $this->get(Service\Service\Instantiate::class)
+            );
+        }, $this->namespace);
 
         return $service;
     }

--- a/src/Project/Service/Validate.php
+++ b/src/Project/Service/Validate.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * @copyright  2018 Jack Clayton
+ * @license    MIT
+ */
+
+namespace Jstewmc\Gravity\Project\Service;
+
+use Jstewmc\Gravity\Manager\Data\Manager;
+use Jstewmc\Gravity\Project\Data\Project;
+use Jstewmc\Gravity\Service\Data\Service;
+use Jstewmc\Gravity\Service\Service\Instantiate;
+use Jstewmc\Gravity\Exception;
+
+class Validate
+{
+    private $instantiate;
+
+    public function __construct(Instantiate $instantiate)
+    {
+        $this->instantiate = $instantiate;
+    }
+
+    public function __invoke(Project $project, Manager $g): array
+    {
+        return array_merge(
+            $this->validateRequirements($project),
+            $this->validateServices($project, $g)
+        );
+    }
+
+    private function instantiate(Service $service, Manager $g): object
+    {
+        return ($this->instantiate)($service, $g);
+    }
+
+    private function validateRequirements(Project $project): array
+    {
+        $errors = [];
+
+        foreach ($project->getRequirements() as $requirement) {
+            if ($requirement->isService()) {
+                if (!$project->hasService($requirement->getKey())) {
+                    $errors[(string)$requirement->getKey()] = "Required "
+                        . "service, '{$requirement->getKey()}', not found";
+                }
+            } else {
+                if (!$project->hasSetting($requirement->getKey())) {
+                    $errors[(string)$requirement->getKey()] = "Required "
+                        . "setting, '{$requirement->getKey()}', not found";
+                }
+            }
+        }
+
+        return $errors;
+    }
+
+    private function validateServices(Project $project, Manager $g): array
+    {
+        $errors = [];
+
+        foreach ($project->getServices() as $service) {
+            try {
+                $this->instantiate($service, $g);
+            } catch (Exception $e) {
+                $errors[(string)$service->getId()] = "Instatiating service, "
+                    . "'{$service->getId()}', failed with " . get_class($e)
+                    . ": " . $e->getMessage();
+            }
+        }
+
+        return $errors;
+    }
+}

--- a/src/Project/Service/Validate.php
+++ b/src/Project/Service/Validate.php
@@ -10,7 +10,6 @@ use Jstewmc\Gravity\Manager\Data\Manager;
 use Jstewmc\Gravity\Project\Data\Project;
 use Jstewmc\Gravity\Service\Data\Service;
 use Jstewmc\Gravity\Service\Service\Instantiate;
-use Jstewmc\Gravity\Exception;
 
 class Validate
 {
@@ -62,7 +61,7 @@ class Validate
         foreach ($project->getServices() as $service) {
             try {
                 $this->instantiate($service, $g);
-            } catch (Exception $e) {
+            } catch (\Throwable $e) {
                 $errors[(string)$service->getId()] = "Instatiating service, "
                     . "'{$service->getId()}', failed with " . get_class($e)
                     . ": " . $e->getMessage();

--- a/src/Requirement/Data/Requirement.php
+++ b/src/Requirement/Data/Requirement.php
@@ -8,11 +8,11 @@ namespace Jstewmc\Gravity\Requirement\Data;
 
 abstract class Requirement
 {
-    private $key;
-
     private $description;
 
     private $validator;
+
+    protected $key;
 
     public function __construct($key, string $description, callable $validator)
     {

--- a/src/Requirement/Data/Resolved.php
+++ b/src/Requirement/Data/Resolved.php
@@ -6,7 +6,7 @@
 
 namespace Jstewmc\Gravity\Requirement\Data;
 
-use Jstewmc\Gravity\Id\Data\Id;
+use Jstewmc\Gravity\Id\Data\{Id, Service, Setting};
 
 class Resolved extends Requirement
 {
@@ -18,5 +18,15 @@ class Resolved extends Requirement
     public function getKey(): Id
     {
         return parent::getKey();
+    }
+
+    public function isService(): bool
+    {
+        return $this->key instanceof Service;
+    }
+
+    public function isSetting(): bool
+    {
+        return $this->key instanceof Setting;
     }
 }

--- a/tests/BinTest.php
+++ b/tests/BinTest.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * @copyright  2018 Jack Clayton
+ * @license    MIT
+ */
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for Gravity's binary file.
+ */
+class BinTest extends TestCase
+{
+    public function testValidate(): void
+    {
+        $root = dirname(__FILE__, 2);
+
+        $expected = "Project is valid!";
+        $actual   = exec("{$root}/gravity validate");
+
+        $this->assertEquals($expected, $actual);
+    }
+}

--- a/tests/BinTest.php
+++ b/tests/BinTest.php
@@ -4,6 +4,8 @@
  * @license    MIT
  */
 
+namespace Jstewmc\Gravity;
+
 use PHPUnit\Framework\TestCase;
 
 /**

--- a/tests/Manager/Data/ManagerTest.php
+++ b/tests/Manager/Data/ManagerTest.php
@@ -42,6 +42,20 @@ class ManagerTest extends TestCase
         $this->assertNull($manager->exit());
     }
 
+    public function testGetProject(): void
+    {
+        $project = $this->createMock(Project\Data\Project::class);
+
+        $manager = new Manager(
+            $project,
+            $this->createMock(Id\Service\Get::class),
+            $this->createMock(Service\Service\Get::class),
+            $this->createMock(Setting\Service\Get::class)
+        );
+
+        $this->assertSame($project, $manager->getProject());
+    }
+
     public function testGetSetting(): void
     {
         $path  = 'foo.bar.baz';

--- a/tests/Project/Data/ProjectTest.php
+++ b/tests/Project/Data/ProjectTest.php
@@ -155,6 +155,11 @@ class ProjectTest extends TestCase
         $this->assertSame($service, $project->getService($id));
     }
 
+    public function testGetServices(): void
+    {
+        $this->assertEquals([], (new Project($this->root))->getServices());
+    }
+
     public function testGetSettingThrowsExceptionIfDoesNotExist(): void
     {
         $this->expectException(SettingNotFound::class);

--- a/tests/Project/Service/ValidateTest.php
+++ b/tests/Project/Service/ValidateTest.php
@@ -8,7 +8,6 @@ namespace Jstewmc\Gravity\Project\Service;
 
 use Jstewmc\Gravity\Exception;
 use Jstewmc\Gravity\Id\Data\{
-    Id,
     Service as ServiceId,
     Setting as SettingId
 };

--- a/tests/Project/Service/ValidateTest.php
+++ b/tests/Project/Service/ValidateTest.php
@@ -1,0 +1,113 @@
+<?php
+/**
+ * @copyright  2018 Jack Clayton
+ * @license    MIT
+ */
+
+namespace Jstewmc\Gravity\Project\Service;
+
+use Jstewmc\Gravity\Exception;
+use Jstewmc\Gravity\Id\Data\{
+    Id,
+    Service as ServiceId,
+    Setting as SettingId
+};
+use Jstewmc\Gravity\Manager\Data\Manager;
+use Jstewmc\Gravity\Project\Data\Project;
+use Jstewmc\Gravity\Requirement\Data\Resolved as Requirement;
+use Jstewmc\Gravity\Service\Data\Service;
+use Jstewmc\Gravity\Service\Service\Instantiate;
+use PHPUnit\Framework\TestCase;
+
+class ValidateTest extends TestCase
+{
+    private $manager;
+
+    public function setUp(): void
+    {
+        $this->manager = $this->createMock(Manager::class);
+    }
+
+    public function testInvokeIfProjectIsValid(): void
+    {
+        $project = $this->createMock(Project::class);
+        $project->method('getRequirements')->willReturn([]);
+        $project->method('getServices')->willReturn([]);
+
+        $instantiate = $this->createMock(Instantiate::class);
+
+        $sut = new Validate($instantiate);
+
+        $this->assertEmpty($sut($project, $this->manager));
+    }
+
+    public function testInvokeIfServiceRequirementIsInvalid(): void
+    {
+        $key = 'foo\bar\baz';
+
+        $id = $this->createMock(ServiceId::class);
+        $id->method('__toString')->willReturn($key);
+
+        $requirement = $this->createMock(Requirement::class);
+        $requirement->method('isService')->willReturn(true);
+        $requirement->method('getKey')->willReturn($id);
+
+        $project = $this->createMock(Project::class);
+        $project->method('getRequirements')->willReturn([$requirement]);
+        $project->method('getServices')->willReturn([]);
+        $project->method('hasService')->willReturn(false);
+
+        $instantiate = $this->createMock(Instantiate::class);
+
+        $sut = new Validate($instantiate);
+
+        $this->assertArrayHasKey($key, $sut($project, $this->manager));
+    }
+
+    public function testInvokeIfSettingRequirementIsInvalid(): void
+    {
+        $key = 'foo.bar.baz';
+
+        $id = $this->createMock(SettingId::class);
+        $id->method('__toString')->willReturn($key);
+
+        $requirement = $this->createMock(Requirement::class);
+        $requirement->method('isService')->willReturn(false);
+        $requirement->method('getKey')->willReturn($id);
+
+        $project = $this->createMock(Project::class);
+        $project->method('getRequirements')->willReturn([$requirement]);
+        $project->method('getServices')->willReturn([]);
+        $project->method('hasSetting')->willReturn(false);
+
+        $instantiate = $this->createMock(Instantiate::class);
+
+        $sut = new Validate($instantiate);
+
+        $this->assertArrayHasKey($key, $sut($project, $this->manager));
+    }
+
+    public function testInvokeIfServiceDefinitionIsInvalid(): void
+    {
+        $key = 'foo\bar\baz';
+
+        $id = $this->createMock(ServiceId::class);
+        $id->method('__toString')->willReturn($key);
+
+        $service = $this->createMock(Service::class);
+        $service->method('getId')->willReturn($id);
+
+        $project = $this->createMock(Project::class);
+        $project->method('getRequirements')->willReturn([]);
+        $project->method('getServices')->willReturn([$service]);
+
+        $e = $this->createMock(Exception::class);
+
+        $instantiate = $this->createMock(Instantiate::class);
+        $instantiate->method('__invoke')->will($this->throwException($e));
+
+        $sut = new Validate($instantiate);
+
+        $this->assertArrayHasKey($key, $sut($project, $this->manager));
+    }
+}

--- a/tests/Requirement/Data/ResolvedTest.php
+++ b/tests/Requirement/Data/ResolvedTest.php
@@ -6,7 +6,11 @@
 
 namespace Jstewmc\Gravity\Requirement\Data;
 
-use Jstewmc\Gravity\Id\Data\Id;
+use Jstewmc\Gravity\Id\Data\{
+    Id,
+    Service as ServiceId,
+    Setting as SettingId
+};
 use PHPUnit\Framework\TestCase;
 
 class ResolvedTest extends TestCase
@@ -47,5 +51,27 @@ class ResolvedTest extends TestCase
         $requirement = new Resolved($this->key, 'bar', $validator);
 
         $this->assertEquals($validator, $requirement->getValidator());
+    }
+
+    public function testIsService(): void
+    {
+        $key = $this->createMock(ServiceId::class);
+
+        $requirement = new Resolved($key, 'bar', function () {
+            return true;
+        });
+
+        $this->assertTrue($requirement->isService());
+    }
+
+    public function testIsSetting(): void
+    {
+        $key = $this->createMock(SettingId::class);
+
+        $requirement = new Resolved($key, 'bar', function () {
+            return true;
+        });
+
+        $this->assertTrue($requirement->isSetting());
     }
 }


### PR DESCRIPTION
Add the ability to validate the project from the command line: 

```
/path/to/project$ vendor/bin/gravity validate 
```

If the project is invalid, a table of keys and messages will be output to the console. 

As a bonus, testing the project validation identified problems with some of our examples. Woot!

Closes #8.