### PR TITLE
Add environments

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
     }
   ],
   "require": {
+    "jstewmc/detect-environment": "^2.0",
     "php": "^7.2",
     "psr/log": "^1.1",
     "psr/simple-cache": "^1.0"

--- a/docs/identifying.md
+++ b/docs/identifying.md
@@ -63,8 +63,8 @@ Here are a few psuedo-examples with the plumbing of a working example omitted to
 By default, a file without a `namespace` or `use` statements will default to the global namespace, and identifiers will resolve as-is:
 
 ```
-'Foo\Bar\Baz'  // resolves to "Foo\Bar\Baz"
-'foo.bar.baz'  // resolves to "foo.bar.baz"
+$g->set('Foo\Bar\Baz');     // resolves to "Foo\Bar\Baz"
+$g->set('foo.bar.baz', 1);  // resolves to "foo.bar.baz"
 ```
 
 ### With namespace
@@ -74,8 +74,8 @@ When a namespace is defined, it is prepended to every identifier in the file.
 ```
 $g->namespace('foo.bar.baz');
 
-'qux.quux.corge'       // resolves to "foo.bar.baz.qux.quux.corge"
-'grault.garply.waldo'  // resolves to "foo.bar.baz.grault.garply.waldo"
+$g->set('qux.quux.corge', 1);       // resolves to "foo.bar.baz.qux.quux.corge"
+$g->set('grault.garply.waldo', 2);  // resolves to "foo.bar.baz.grault.garply.waldo"
 ```
 
 Unless, you use a leading separator to escape the namespace:
@@ -83,8 +83,8 @@ Unless, you use a leading separator to escape the namespace:
 ```
 $g->namespace('foo.bar.baz');
 
-'qux.quux.corge'   // resolves to "foo.bar.baz.qux.quux.corge"
-'.qux.quux.corge'  // resolves to "qux.quux.corge"
+$g->set('qux.quux.corge', 1);   // resolves to "foo.bar.baz.qux.quux.corge"
+$g->set('.qux.quux.corge', 2);  // resolves to "qux.quux.corge"
 ```
 
 Unfortunately, a namespace is not a great option if you're going to mix settings and services in the same file, because it is prepended to _every_ identifier, regardless of type:
@@ -92,23 +92,22 @@ Unfortunately, a namespace is not a great option if you're going to mix settings
 ```
 $g->namespace('foo.bar.baz');
 
-'qux.quux.corge'  // resolves to "foo.bar.baz.qux.quux.corge" (good!)
-'Qux\Quux\Corge'  // throws exception because types don't match
+$g->set('qux.quux.corge', 1);  // resolves to "foo.bar.baz.qux.quux.corge" (good!)
+$g->set('Qux\Quux\Corge');     // throws an exception because the types don't match
 ```
 
 That is, unless you use imported namespaces.
 
 ### With imports
 
-Imported namespaces are added to a file under an alias. If an alias is not explictly defined, the last segment in the namespace will be used:
+Imported namespaces are added to a file under an alias. If an alias is not explicitly defined, the last segment in the namespace will be used as its alias:
 
 ```
 $g->use('Foo\Bar\Baz');         // uses the implicit alias "baz"
-$g->use('Foo\Bar\Baz', 'Baz');  // uses the explicit alias "baz"
-$g->use('Foo\Bar\Baz', 'Qux');  // uses the explicit alias "qux"
+$g->use('Foo\Bar\Baz', 'Bar');  // uses the explicit alias "bar"
 ```
 
-You can use as many imports namespaces as you like in a file.
+You can use as many imported namespaces as you'd like in a file.
 
 Imported namespaces are resolved before the file's namespace. So, if you mix services and settings in the same file, you can use a namespace for one type and imported namespaces for another:
 
@@ -117,8 +116,8 @@ $g->namespace('foo.bar.baz');
 
 $g->use('Foo\Bar\Baz');
 
-'qux.quux.corge'      // resolves to "foo.bar.baz.qux.quux.corge"
-'Baz\Qux\Quux\Corge'  // resolves to "Foo\Bar\Baz\Qux\Quux\Corge"
+$g->set('qux.quux.corge');      // resolves to "foo.bar.baz.qux.quux.corge"
+$g->set('Baz\Qux\Quux\Corge');  // resolves to "Foo\Bar\Baz\Qux\Quux\Corge"
 ```
 
 Just be careful of alias collisions. The last alias will always win:
@@ -127,7 +126,7 @@ Just be careful of alias collisions. The last alias will always win:
 $g->use('foo.bar.baz');
 $g->use('Foo\Bar\Baz');
 
-'baz.qux.quux.corge'  // throws an exception because the last "baz" alis won!
+$g->set('baz.qux.quux.corge', 1)  // throws an exception for type mismatch
 ```
 
 ### Rules

--- a/docs/validating.md
+++ b/docs/validating.md
@@ -1,0 +1,32 @@
+[Home](index.md) | [Identifying](identifying.md) | [Setting](setting.md) | [Getting](getting.md) | [Aliasing](aliasing.md) | [Deprecating](deprecating.md) | [Logging](logging.md) | [Caching](caching.md)
+
+# Validating a project
+
+Gravity allows developers to define required services and settings for their packages with an identifier and a description:
+
+```php
+$g->require('Foo\Bar\Baz', 'Lorem ipsum inum');
+$g->require('foo.bar.baz', 'Dolor amet');
+```
+
+To check a project's requirements are met (and that all services can be instantiated successfully), Gravity provides a command-line tool, `gravity validate`:
+
+```bash
+/path/to/project $ gravity validate
+```
+
+If a project's requirements are met and all services can be instantiated without error, `validate` will print a success message:
+
+```bash
+/path/to/project $ gravity validate
+Project is valid!
+```
+
+It not, `validate` will print error messages as a bulleted list:
+
+```bash
+/path/to/project $ gravity validate
+Project is invalid! Found 1 errors:
+
+    * jstewmc\gravity\example\service\quux: Instatiating service, 'jstewmc\gravity\example\service\quux', failed with Error: Class 'Jstewmc\Gravity\Example\Service\Asdf' not found
+```

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -13,6 +13,9 @@
     		<directory suffix=".php">tests</directory>
     	</testsuite>
     </testsuites>
+    <php>
+        <env name="GRAVITY_ENV" value="test" force="true" />
+    </php>
     <filter>
         <whitelist processUncoveredFilesFromWhitelist="true">
             <directory suffix=".php">./src</directory>

--- a/src/Filesystem/Service/Traverse.php
+++ b/src/Filesystem/Service/Traverse.php
@@ -9,10 +9,19 @@ namespace Jstewmc\Gravity\Filesystem\Service;
 use DirectoryIterator;
 use Jstewmc\Gravity\Filesystem\Data\Traversed;
 use Jstewmc\Gravity\Root\Data\Root;
-use Psr\Log\LoggerInterface;
+use Psr\Log\LoggerInterface as Logger;
 use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
 use SplFileInfo;
+use function array_values,
+    count,
+    implode,
+    is_dir,
+    is_file,
+    is_readable,
+    iterator_to_array,
+    number_format,
+    strpos;
 
 class Traverse
 {
@@ -22,29 +31,124 @@ class Traverse
      * @param  string[]  $directories  an array of directory names with keys
      *   "gravity" and "vendors"
      */
-    public function __construct(array $directories, LoggerInterface $logger)
+    public function __construct(array $directories, Logger $logger)
     {
         $this->directories = $directories;
         $this->logger      = $logger;
     }
 
-    public function __invoke(Root $root): Traversed
+    /**
+     * Project files take precedence over package files so the user's settings
+     * win, and local environment files should take precedence over global
+     * environment files so the local enviornment wins.
+     */
+    public function __invoke(Root $root, string $environment = null): Traversed
     {
-        $this->logger->info("Starting traversal of $root...");
+        $this->before($root, $environment);
 
-        $projectFiles = $this->getProjectFiles($root);
-        $packageFiles = $this->getPackageFiles($root);
+        $pathnames = $this->getPackageGravityDirectoryPathnames($root);
 
-        $files = array_merge($projectFiles, $packageFiles);
+        if ($pathnames) {
+            $packageGlobal = $this->getPackageGlobalFiles($pathnames);
+            if ($environment) {
+                $packageLocal  = $this->getPackageLocalFiles($pathnames, $environment);
+            }
+        }
 
-        $total = number_format(count($files));
-        $this->logger->info("Found $total files.");
+        $pathname = $this->getProjectGravityDirectoryPathname($root);
+
+        if ($pathname) {
+            $projectGlobal = $this->getProjectGlobalFiles($pathname);
+            if ($environment) {
+                $projectLocal  = $this->getProjectLocalFiles($pathname, $environment);
+            }
+        }
+
+        $files = array_merge(
+            $packageGlobal ?? [],
+            $projectGlobal ?? [],
+            $packageLocal ?? [],
+            $projectLocal ?? []
+        );
 
         $filesystem = new Traversed($files);
+
+        $this->after($files);
 
         return $filesystem;
     }
 
+
+    private function after(array $files): void
+    {
+        $total = number_format(count($files));
+
+        $this->logger->info("Found $total files.");
+    }
+
+    private function before(string $root, string $environment = null): void
+    {
+        $message = "Starting traversal of $root";
+
+        if ($environment) {
+            $message .= " in $environment";
+        }
+
+        $message .= '...';
+
+        $this->logger->info($message);
+    }
+
+    /**
+     * @return  SplFileInfo[]
+     */
+    private function getEnvironmentFiles(string $gravity, string $environment): array
+    {
+        $files = [];
+
+        // get the expected file and directory pathnames
+        $file      = $this->implode($gravity, 'environments', "$environment.php");
+        $directory = $this->implode($gravity, 'environments', $environment);
+
+        if ($this->isFile($file)) {
+            $files[] = new SplFileInfo($file);
+        } elseif ($this->isDirectory($directory)) {
+            $files = $this->getLocalFiles($directory);
+        }
+
+        return $files;
+    }
+
+    /**
+     * Recursively lists all non-environment files in a gravity directory
+     *
+     * @return  SplFileInfo[]
+     */
+    private function getGlobalFiles(string $directory): array
+    {
+        $files = [];
+
+        $rdi = new RecursiveDirectoryIterator(
+            $directory,
+            RecursiveDirectoryIterator::SKIP_DOTS
+        );
+
+        $rii = new RecursiveIteratorIterator(
+            $rdi,
+            RecursiveIteratorIterator::LEAVES_ONLY
+        );
+
+        // include files that do not start with the environments directory
+        $environments = $this->implode($directory, 'environments');
+
+        foreach ($rii as $item) {
+            if (strpos($item->getPathname(), $environments) !== 0) {
+                $files[] = $item;
+            }
+        }
+
+        return $files;
+    }
 
     private function getGravityDirectoryName(): string
     {
@@ -52,14 +156,14 @@ class Traverse
     }
 
     /**
-     * Recursively lists the files in a directory
+     * Recursively lists all files in an environment directory
      *
      * @return  SplFileInfo[]
      */
-    private function getFiles(string $pathname): array
+    private function getLocalFiles(string $directory)
     {
         $rdi = new RecursiveDirectoryIterator(
-            $pathname,
+            $directory,
             RecursiveDirectoryIterator::SKIP_DOTS
         );
 
@@ -74,14 +178,31 @@ class Traverse
     /**
      * @return  SplFileInfo[]
      */
-    private function getPackageFiles(string $root): array
+    private function getPackageGlobalFiles(array $directories): array
     {
         $files = [];
 
-        $pathnames = $this->getPackageGravityDirectoryPathnames($root);
+        foreach ($directories as $directory) {
+            $files = array_merge($files, $this->getGlobalFiles($directory));
+        }
 
-        foreach ($pathnames as $pathname) {
-            $files = array_merge($files, $this->getFiles($pathname));
+        return $files;
+    }
+
+    /**
+     * @return  SplFileInfo[]
+     */
+    private function getPackageLocalFiles(
+        array  $directories,
+        string $environment = null
+    ): array {
+        $files = [];
+
+        foreach ($directories as $directory) {
+            $files = array_merge(
+                $files,
+                $this->getEnvironmentFiles($directory, $environment)
+            );
         }
 
         return $files;
@@ -128,22 +249,21 @@ class Traverse
     /**
      * @return  SplFilInfo[]
      */
-    private function getProjectFiles(string $root): array
+    private function getProjectGlobalFiles(string $directory): array
     {
-        $files = [];
-
-        $pathname = $this->getProjectGravityDirectoryPathname($root);
-
-        if ($this->isDirectory($pathname)) {
-            $files = $this->getFiles($pathname);
-        }
-
-        return $files;
+        return $this->getGlobalFiles($directory);
     }
 
-    private function getProjectGravityDirectoryPathname(string $root): string
+    private function getProjectGravityDirectoryPathname(string $root): ?string
     {
-        return $this->implode($root, $this->getGravityDirectoryName());
+        $pathname = $this->implode($root, $this->getGravityDirectoryName());
+
+        return $this->isDirectory($pathname) ? $pathname : null;
+    }
+
+    private function getProjectLocalFiles(string $directory, string $environment): array
+    {
+        return $this->getEnvironmentFiles($directory, $environment);
     }
 
     private function getVendorsDirectoryName(): string
@@ -154,6 +274,11 @@ class Traverse
     private function implode(string ...$segments): string
     {
         return implode(DIRECTORY_SEPARATOR, $segments);
+    }
+
+    private function isFile(string $pathname): bool
+    {
+        return is_readable($pathname) && is_file($pathname);
     }
 
     private function isDirectory(string $pathname): bool

--- a/src/Filesystem/Service/Traverse.php
+++ b/src/Filesystem/Service/Traverse.php
@@ -42,7 +42,7 @@ class Traverse
      * win, and local environment files should take precedence over global
      * environment files so the local enviornment wins.
      */
-    public function __invoke(Root $root, string $environment = null): Traversed
+    public function __invoke(Root $root, string $environment): Traversed
     {
         $this->before($root, $environment);
 
@@ -50,18 +50,14 @@ class Traverse
 
         if ($pathnames) {
             $packageGlobal = $this->getPackageGlobalFiles($pathnames);
-            if ($environment) {
-                $packageLocal  = $this->getPackageLocalFiles($pathnames, $environment);
-            }
+            $packageLocal  = $this->getPackageLocalFiles($pathnames, $environment);
         }
 
         $pathname = $this->getProjectGravityDirectoryPathname($root);
 
         if ($pathname) {
             $projectGlobal = $this->getProjectGlobalFiles($pathname);
-            if ($environment) {
-                $projectLocal  = $this->getProjectLocalFiles($pathname, $environment);
-            }
+            $projectLocal  = $this->getProjectLocalFiles($pathname, $environment);
         }
 
         $files = array_merge(

--- a/tests/Filesystem/Service/TraverseTest.php
+++ b/tests/Filesystem/Service/TraverseTest.php
@@ -42,7 +42,7 @@ class TraverseTest extends TestCase
         return;
     }
 
-    public function testInvokeReturnsFilesystemIfEmpty(): void
+    public function testInvokeIfEmpty(): void
     {
         $root = new Root($this->root->url());
 
@@ -56,7 +56,7 @@ class TraverseTest extends TestCase
         return;
     }
 
-    public function testInvokeReturnsFilesystemIfProjectHasFiles(): void
+    public function testInvokeIfProjectHasFiles(): void
     {
         $root = new Root($this->root->url());
 
@@ -91,7 +91,7 @@ class TraverseTest extends TestCase
         return;
     }
 
-    public function testInvokeReturnsFilesystemIfPackagesHaveFiles(): void
+    public function testInvokeIfPackagesHaveFiles(): void
     {
         $root = new Root($this->root->url());
 
@@ -128,6 +128,188 @@ class TraverseTest extends TestCase
             new SplFileInfo($file3->url())
         ]);
         $actual = $sut($root);
+
+        $this->assertEquals($expected, $actual);
+
+        return;
+    }
+
+    public function testInvokeIfEnvironmentHasFiles(): void
+    {
+        $root = new Root($this->root->url());
+
+        // create Composer's directory in the project's root
+        $vendors = vfsStream::newDirectory(
+            $this->directories['vendors']
+        )->at($this->root);
+
+        // create a vendor, package, gravity, and environments directory
+        $vendor1  = vfsStream::newDirectory('vendor1')->at($vendors);
+        $package1 = vfsStream::newDirectory('package1')->at($vendor1);
+        $gravity1 = vfsStream::newDirectory($this->directories['gravity'])
+            ->at($package1);
+        $env1     = vfsStream::newDirectory('environments')->at($gravity1);
+        $file1    = vfsStream::newFile('foo.php')->at($env1);
+
+        // create a second vendor, package, and gravity directory
+        $vendor2  = vfsStream::newDirectory('vendor2')->at($vendors);
+        $package2 = vfsStream::newDirectory('package1')->at($vendor2);
+        $gravity2 = vfsStream::newDirectory($this->directories['gravity'])
+            ->at($package2);
+        $env2     = vfsStream::newDirectory('environments')->at($gravity2);
+        $file2    = vfsStream::newFile('foo.php')->at($env2);
+
+        // create a second package in the second vendor directory
+        $package3 = vfsStream::newDirectory('package2')->at($vendor2);
+        $gravity3 = vfsStream::newDirectory($this->directories['gravity'])
+            ->at($package3);
+        $env3     = vfsStream::newDirectory('environments')->at($gravity3);
+        $file3    = vfsStream::newFile('foo.php')->at($env3);
+
+        $sut = new Traverse($this->directories, $this->logger);
+
+        $expected = new Traversed([
+            new SplFileInfo($file1->url()),
+            new SplFileInfo($file2->url()),
+            new SplFileInfo($file3->url())
+        ]);
+        $actual = $sut($root, 'foo');
+
+        $this->assertEquals($expected, $actual);
+
+        return;
+    }
+
+    public function testInvokeIfEnvironmentHasDirectories(): void
+    {
+        $root = new Root($this->root->url());
+
+        // create Composer's directory
+        $vendors = vfsStream::newDirectory(
+            $this->directories['vendors']
+        )->at($this->root);
+
+        // create a vendor, package, gravity, and environments directory
+        $vendor1  = vfsStream::newDirectory('vendor1')->at($vendors);
+        $package1 = vfsStream::newDirectory('package1')->at($vendor1);
+        $gravity1 = vfsStream::newDirectory($this->directories['gravity'])
+            ->at($package1);
+        $env1     = vfsStream::newDirectory('environments')->at($gravity1);
+        $foo1     = vfsStream::newDirectory('foo')->at($env1);
+        $file1    = vfsStream::newFile('bar.php')->at($foo1);
+
+        // create a second vendor, package, and gravity directory
+        $vendor2  = vfsStream::newDirectory('vendor2')->at($vendors);
+        $package2 = vfsStream::newDirectory('package1')->at($vendor2);
+        $gravity2 = vfsStream::newDirectory($this->directories['gravity'])
+            ->at($package2);
+        $env2     = vfsStream::newDirectory('environments')->at($gravity2);
+        $foo2     = vfsStream::newDirectory('foo')->at($env2);
+        $file2    = vfsStream::newFile('baz.php')->at($foo2);
+
+        // create a second package in the second vendor directory
+        $package3 = vfsStream::newDirectory('package2')->at($vendor2);
+        $gravity3 = vfsStream::newDirectory($this->directories['gravity'])
+            ->at($package3);
+        $env3     = vfsStream::newDirectory('environments')->at($gravity3);
+        $foo3     = vfsStream::newDirectory('foo')->at($env3);
+        $file3    = vfsStream::newFile('qux.php')->at($foo3);
+
+        $sut = new Traverse($this->directories, $this->logger);
+
+        $expected = new Traversed([
+            new SplFileInfo($file1->url()),
+            new SplFileInfo($file2->url()),
+            new SplFileInfo($file3->url())
+        ]);
+        $actual = $sut($root, 'foo');
+
+        $this->assertEquals($expected, $actual);
+
+        return;
+    }
+
+    public function testInvokeExcludesOtherEnvironmentFiles(): void
+    {
+        $root = new Root($this->root->url());
+
+        $environment = 'foo';
+
+        // create a project-level gravity directory
+        $gravity = vfsStream::newDirectory(
+            $this->directories['gravity']
+        )->at($this->root);
+
+        // create an environments directory
+        $environments = vfsStream::newDirectory('environments')->at($gravity);
+
+        // create a file with the environment name
+        $filename = "{$environment}.php";
+        $file1 = vfsStream::newFile($filename)->at($environments);
+
+        // create a file without the environment name
+        $filename = strrev($environment) . '.php';
+        $file2 = vfsStream::newFile($filename)->at($environments);
+
+        $sut = new Traverse($this->directories, $this->logger);
+
+        $expected = new Traversed([
+            new SplFileInfo($file2->url()),
+        ]);
+        $actual = $sut($root, $environment);
+
+        $this->assertEquals($expected, $actual);
+
+        return;
+    }
+
+    public function testInvokeReturnsFilesInOrder(): void
+    {
+        $root = new Root($this->root->url());
+
+        $environment = 'foo';
+
+        // create a project-level gravity directory
+        $gravity = vfsStream::newDirectory(
+            $this->directories['gravity']
+        )->at($this->root);
+
+        // create a global project file
+        $file1 = vfsStream::newFile('foo.php')->at($gravity);
+
+        // create a local project file
+        $environments = vfsStream::newDirectory('environments')->at($gravity);
+        $filename     = "{$environment}.php";
+        $file2        = vfsStream::newFile($filename)->at($environments);
+
+        // create Composer directory
+        $vendors = vfsStream::newDirectory(
+            $this->directories['vendors']
+        )->at($this->root);
+
+        // create a vendor, package, gravity, and environments directory
+        $vendor1  = vfsStream::newDirectory('vendor1')->at($vendors);
+        $package1 = vfsStream::newDirectory('package1')->at($vendor1);
+        $gravity1 = vfsStream::newDirectory($this->directories['gravity'])
+            ->at($package1);
+
+        // create a global package file
+        $file3 = vfsStream::newFile('foo.php')->at($gravity1);
+
+        // create a local package file
+        $environments1 = vfsStream::newDirectory('environments')->at($gravity1);
+        $file4 = vfsStream::newFile($filename)->at($environments1);
+
+        $sut = new Traverse($this->directories, $this->logger);
+
+        // expect package global, project global, package local, project local
+        $expected = new Traversed([
+            new SplFileInfo($file3->url()),
+            new SplFileInfo($file1->url()),
+            new SplFileInfo($file4->url()),
+            new SplFileInfo($file2->url())
+        ]);
+        $actual = $sut($root, $environment);
 
         $this->assertEquals($expected, $actual);
 

--- a/tests/Filesystem/Service/TraverseTest.php
+++ b/tests/Filesystem/Service/TraverseTest.php
@@ -49,7 +49,7 @@ class TraverseTest extends TestCase
         $sut = new Traverse($this->directories, $this->logger);
 
         $expected = new Traversed([]);
-        $actual   = $sut($root);
+        $actual   = $sut($root, 'foo');
 
         $this->assertEquals($expected, $actual);
 
@@ -84,7 +84,7 @@ class TraverseTest extends TestCase
             new SplFileInfo($file2->url()),
             new SplFileInfo($file3->url())
         ]);
-        $actual = $sut($root);
+        $actual = $sut($root, 'foo');
 
         $this->assertEquals($expected, $actual);
 
@@ -127,7 +127,7 @@ class TraverseTest extends TestCase
             new SplFileInfo($file2->url()),
             new SplFileInfo($file3->url())
         ]);
-        $actual = $sut($root);
+        $actual = $sut($root, 'foo');
 
         $this->assertEquals($expected, $actual);
 


### PR DESCRIPTION
Add support for environment-aware services and settings.

## New environment variable 

Gravity now looks for an environment variable `GRAVITY_ENV` with one of the following case-insensitive values: 

* development
* test
* staging
* production

If the environment variable is not set, it will default to `development`.

## Environment files 

Gravity looks for environment-specific services in settings in the `.gravity/environments` directory. 

Services and settings may be defined in files named after each environment:

```
/path/to/package
|-- .gravity
|   |-- environments
|   |   |-- development.php
|   |   |-- test.php
|   |   |-- staging.php
|   |   |-- production.php 
|-- ...
```

Or, they may be broken into multiple files in a directory named after the environment: 

```
/path/to/package
|-- .gravity
|   |-- environments
|   |   |-- development 
|   |   |   |-- foo.php 
|   |   |   |-- bar.php
|   |   |-- test 
|   |   |   |-- foo.php 
|   |   |   |-- bar.php 
|   |   |-- staging 
|   |   |   |-- foo.php 
|   |   |   |-- bar.php 
|   |   |-- production 
|   |   |   |-- foo.php 
|   |   |   |-- bar.php  
|-- ...
```

Keep in mind, don't mix methods. If both a directory and file exist (e.g., `environments\development` and `environments\development.php`, respectively), the file will win. 

Also, environment files are not required and may be sparse. You can define as many (or as few) as you'd like.

Closes #30.