### PR TITLE
Fix binary file

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,10 +4,9 @@
   "license": "MIT",
   "keywords": [
     "php",
-    "jstewmc",
     "gravity",
-    "service",
-    "configuration",
+    "services",
+    "settings",
     "manager"
   ],
   "authors": [
@@ -37,5 +36,8 @@
     "files": [
       "src/uarray_merge_recursive.php"
     ]
-  }
+  },
+  "bin": [
+    "gravity"
+  ]
 }


### PR DESCRIPTION
Add the `bin` key to `composer.json` with the `gravity` binary file. 

Hmm, I forgot to do that somewhere in #42.