### PR TITLE
Verify private method access

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,12 @@
 # Gravity
 
-Gravity is like Composer for settings and services: other developers can define settings and services in your dependency injection container from files in their packages, no framework conventions to follow, no glue code required. By pulling everything together, Gravity makes it easy to build and share small, configurable services.
+Gravity is like Composer for settings and services: other developers define settings and services in your dependency injection container using files in their packages. By pulling everything together, Gravity makes it easy to build and share small, configurable services.
 
 [![Build Status](https://travis-ci.com/jstewmc/gravity.svg?branch=master)](https://travis-ci.com/jstewmc/gravity) [![codecov](https://codecov.io/gh/jstewmc/gravity/branch/master/graph/badge.svg)](https://codecov.io/gh/jstewmc/gravity)
 
 ## Usage
 
 Gravity serves two audiences: _package authors_, the developers who create packages, and _package consumers_, the developers who use them.
-
-### As an author
 
 As a package author, you'll define services and settings in your repository using a simple file-based DSL:
 
@@ -19,17 +17,12 @@ $g->set('foo.bar.baz', true);            // defines a setting
 $g->set('Foo\Bar\Baz', new StdClass());  // defines a service
 ```
 
-## As a consumer
-
 As a package consumer, you'll install packages via Composer; call Gravity's `pull()` method; and, request your service or setting using the `get()` method:
 
 ```php
 # /path/to/project/file.php
 
-use Jstewmc\Gravity\Gravity;
-
-// returns Gravity's setting and service manager
-$g = (new Gravity())->pull();
+$g = (new \Jstewmc\Gravity\Gravity())->pull();  // returns Gravity's manager
 
 $g->get('foo.bar.baz');  // returns true
 $g->get('Foo\Bar\Baz');  // returns the StdClass instance

--- a/tests/Service/Service/InstantiateTest.php
+++ b/tests/Service/Service/InstantiateTest.php
@@ -6,6 +6,7 @@
 
 namespace Jstewmc\Gravity\Service\Service;
 
+use Error;
 use Jstewmc\Gravity\FactoryTest;
 use Jstewmc\Gravity\Id\Data\Service as Id;
 use Jstewmc\Gravity\Manager\Data\Manager;
@@ -35,8 +36,6 @@ class InstantiateTest extends TestCase
         $sut = new Instantiate();
 
         $this->assertInstanceOf(StdClass::class, $sut($service, $this->g));
-
-        return;
     }
 
     public function testInvokeIfFx(): void
@@ -51,8 +50,26 @@ class InstantiateTest extends TestCase
         $sut = new Instantiate();
 
         $this->assertInstanceOf(StdClass::class, $sut($service, $this->g));
+    }
 
-        return;
+    public function testInvokeIfFxCallsPrivateMethods(): void
+    {
+        $namespace = $this->createMock(Ns::class);
+
+        $function  = function () {
+            $this->getId('foo.bar.baz');
+        };
+
+        $service = new Fx($this->id, $function, $namespace);
+
+        // hmm, I (Jack) couldn't figure out to get PHPUnit to expect an error;
+        //     the expectException(Error::class) didn't work
+        try {
+            (new Instantiate())($service, $this->g);
+            $this->assertTrue(false, "Closure accessed manager's private methods");
+        } catch (Error $e) {
+            $this->assertTrue(true);
+        }
     }
 
     public function testInvokeIfInstance()
@@ -62,8 +79,6 @@ class InstantiateTest extends TestCase
         $sut = new Instantiate();
 
         $this->assertInstanceOf(StdClass::class, $sut($service, $this->g));
-
-        return;
     }
 
     public function testInvokeIfNewable()
@@ -75,7 +90,5 @@ class InstantiateTest extends TestCase
         $sut = new Instantiate();
 
         $this->assertInstanceOf(StdClass::class, $sut($service, $this->g));
-
-        return;
     }
 }

--- a/tests/Service/Service/InstantiateTest.php
+++ b/tests/Service/Service/InstantiateTest.php
@@ -16,70 +16,65 @@ use StdClass;
 
 class InstantiateTest extends TestCase
 {
+    private $g;
+
+    private $id;
+
+    public function setUp(): void
+    {
+        $this->id = $this->createMock(Id::class);
+        $this->g  = $this->createMock(Manager::class);
+    }
+
     public function testInvokeIfFactory()
     {
-        $service = new Factory(
-            $this->createMock(Id::class),
-            FactoryTest::class
-        );
+        $service = new Factory($this->id, FactoryTest::class);
 
-        $manager = $this->createMock(Manager::class);
-        $manager->method('get')->willReturn(new FactoryTest());
+        $this->g->method('get')->willReturn(new FactoryTest());
 
         $sut = new Instantiate();
 
-        $this->assertInstanceOf(StdClass::class, $sut($service, $manager));
+        $this->assertInstanceOf(StdClass::class, $sut($service, $this->g));
 
         return;
     }
 
     public function testInvokeIfFx(): void
     {
-        $service = new Fx(
-            $this->createMock(Id::class),
-            function () {
-                return new StdClass();
-            },
-            $this->createMock(Ns::class)
-        );
+        $namespace = $this->createMock(Ns::class);
+        $function  = function () {
+            return new StdClass();
+        };
 
-        $manager = $this->createMock(Manager::class);
+        $service = new Fx($this->id, $function, $namespace);
 
         $sut = new Instantiate();
 
-        $this->assertInstanceOf(StdClass::class, $sut($service, $manager));
+        $this->assertInstanceOf(StdClass::class, $sut($service, $this->g));
 
         return;
     }
 
     public function testInvokeIfInstance()
     {
-        $service = new Instance(
-            $this->createMock(Id::class),
-            new StdClass()
-        );
-
-        $manager = $this->createMock(Manager::class);
+        $service = new Instance($this->id, new StdClass());
 
         $sut = new Instantiate();
 
-        $this->assertInstanceOf(StdClass::class, $sut($service, $manager));
+        $this->assertInstanceOf(StdClass::class, $sut($service, $this->g));
 
         return;
     }
 
     public function testInvokeIfNewable()
     {
-        $id = $this->createMock(Id::class);
-        $id->method('getSegments')->willReturn(['StdClass']);
+        $this->id->method('getSegments')->willReturn(['StdClass']);
 
-        $service = new Newable($id);
-
-        $manager = $this->createMock(Manager::class);
+        $service = new Newable($this->id);
 
         $sut = new Instantiate();
 
-        $this->assertInstanceOf(StdClass::class, $sut($service, $manager));
+        $this->assertInstanceOf(StdClass::class, $sut($service, $this->g));
 
         return;
     }


### PR DESCRIPTION
Shorten the README introductory paragraph; clean up the `Service\Service\InstantiateTest` to use private properties and the `setUp()` method to create things every test needs; and, add a test verifying anonymous function service definitions can't access the manager's private methods. 

I couldn't figure out a way to get PHPUnit to expect an Error. So, I just wrapped the expected-exception-throwing code in a try-catch. If the code throws an exception, assert true is true. Otherwise, assert true if false and fail.

Closes #49.