### PR TITLE
Shorten some copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,12 @@
 # Gravity
 
-Gravity is like Composer for settings and services: other developers define settings and services in your dependency injection container using files in their packages. By pulling everything together, Gravity makes it easy to build and share small, configurable services.
+Gravity lets other developers define settings and services in _your_ dependency injection container using files in _their_ packages. By pulling everything together, Gravity makes it easy to build and share small, configurable services.
 
 [![Build Status](https://travis-ci.com/jstewmc/gravity.svg?branch=master)](https://travis-ci.com/jstewmc/gravity) [![codecov](https://codecov.io/gh/jstewmc/gravity/branch/master/graph/badge.svg)](https://codecov.io/gh/jstewmc/gravity)
 
 ## Usage
 
-Gravity serves two audiences: _package authors_, the developers who create packages, and _package consumers_, the developers who use them.
-
-As a package author, you'll define services and settings in your repository using a simple file-based DSL:
+As a _package author_, you'll define services and settings in your repository using a simple file-based DSL:
 
 ```php
 # /path/to/project/.gravity/foo.php
@@ -17,7 +15,7 @@ $g->set('foo.bar.baz', true);            // defines a setting
 $g->set('Foo\Bar\Baz', new StdClass());  // defines a service
 ```
 
-As a package consumer, you'll install packages via Composer; call Gravity's `pull()` method; and, request your service or setting using the `get()` method:
+As a _package consumer_, you'll install packages via Composer; call Gravity's `pull()` method; and, request services and settings using the `get()` method:
 
 ```php
 # /path/to/project/file.php


### PR DESCRIPTION
Shorten the introductory paragraph and remove the explanation about _package authors_ and _package consumers_. Everybody knows what those are haha.